### PR TITLE
feat: Implement Certificate Verification Contract

### DIFF
--- a/backend/src/certificate_issuance.rs
+++ b/backend/src/certificate_issuance.rs
@@ -10,6 +10,7 @@ pub enum DataKey {
     Issuer(Address),        // Issuer address -> authorized status
     Admin,                  // Admin address
     CertificateCount,       // Total number of certificates
+    VerificationHistory(String), // Certificate ID -> Vec<VerificationResult>
 }
 
 /// Events emitted by the contract
@@ -195,14 +196,7 @@ impl CertificateContract {
         Ok(())
     }
 
-    /// Verify if a certificate is valid (exists and is active)
-    pub fn verify_certificate(env: Env, id: String) -> bool {
-        if let Ok(certificate) = Self::get_certificate(env, id) {
-            certificate.status == CertificateStatus::Active
-        } else {
-            false
-        }
-    }
+    // Old verify_certificate removed. Implemented in certificate_verification.rs
 
     /// Get total number of certificates issued
     pub fn get_certificate_count(env: Env) -> u64 {

--- a/backend/src/certificate_verification.rs
+++ b/backend/src/certificate_verification.rs
@@ -1,0 +1,104 @@
+use soroban_sdk::{contractimpl, Address, Env, String, Vec, symbol_short};
+use crate::types::{Certificate, CertificateStatus, VerificationResult, CertificateVerifiedEvent};
+use crate::certificate_issuance::{CertificateContract, DataKey};
+
+#[contractimpl]
+impl CertificateContract {
+    /// Verify a certificate and record the attempt
+    pub fn verify_certificate(env: Env, id: String, verifier: Address) -> VerificationResult {
+        // 1. Check existence and basic status
+        let cert_key = DataKey::Certificate(id.clone());
+        let certificate_result = env.storage().instance().get::<DataKey, Certificate>(&cert_key);
+
+        let mut is_valid = true;
+        let mut status = CertificateStatus::Active; // Default placeholder
+        let mut message = String::from_str(&env, "Valid");
+
+        if certificate_result.is_none() {
+            is_valid = false;
+            message = String::from_str(&env, "Certificate not found");
+             return VerificationResult {
+                is_valid: false,
+                status: CertificateStatus::Revoked,
+                message,
+                verified_at: env.ledger().timestamp(),
+            };
+        }
+
+        let certificate = certificate_result.unwrap();
+        status = certificate.status.clone();
+
+        // 2. Check if revoked
+        if certificate.status == CertificateStatus::Revoked {
+            is_valid = false;
+            message = String::from_str(&env, "Certificate is revoked");
+        }
+
+        // 3. Check expiration
+        let current_ts = env.ledger().timestamp();
+        if certificate.metadata.valid_until > 0 && current_ts > certificate.metadata.valid_until {
+            is_valid = false;
+            status = CertificateStatus::Expired;
+            message = String::from_str(&env, "Certificate has expired");
+        }
+
+        // 4. Validate signature (Issuer authorization check)
+        // We verify that the issuer is still an authorized issuer in the system
+        if !Self::validate_issuer(env.clone(), certificate.issuer.clone()) {
+            is_valid = false;
+            message = String::from_str(&env, "Issuer is no longer authorized");
+        }
+
+        let result = VerificationResult {
+            is_valid,
+            status,
+            message,
+            verified_at: current_ts,
+        };
+
+        // 5. Record verification
+        Self::record_verification(env.clone(), id.clone(), verifier.clone(), result.clone());
+
+        // 6. Emit event
+        env.events().publish(
+            (symbol_short!("cert_ver"),),
+            CertificateVerifiedEvent {
+                id,
+                verifier,
+                result: result.clone(),
+            },
+        );
+
+        result
+    }
+
+    /// Helper to record verification history
+    fn record_verification(env: Env, id: String, verifier: Address, result: VerificationResult) {
+        let history_key = DataKey::VerificationHistory(id.clone());
+        let mut history: Vec<VerificationResult> = env
+            .storage()
+            .instance()
+            .get(&history_key)
+            .unwrap_or(Vec::new(&env));
+        
+        history.push_back(result);
+        env.storage().instance().set(&history_key, &history);
+    }
+
+    /// Check if certificate is expired (Public helper)
+    pub fn check_expiration(env: Env, valid_until: u64) -> bool {
+        if valid_until == 0 {
+            return false;
+        }
+        env.ledger().timestamp() > valid_until
+    }
+
+    /// Retrieve verification history
+    pub fn get_verification_history(env: Env, id: String) -> Vec<VerificationResult> {
+        let history_key = DataKey::VerificationHistory(id);
+        env.storage()
+            .instance()
+            .get(&history_key)
+            .unwrap_or(Vec::new(&env))
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -5,6 +5,9 @@ mod certificate_issuance;
 
 pub use types::*;
 pub use certificate_issuance::*;
+pub use certificate_verification::*;
+
+mod certificate_verification;
 
 #[cfg(test)]
 mod test;

--- a/backend/src/types.rs
+++ b/backend/src/types.rs
@@ -17,6 +17,7 @@ pub struct CertificateMetadata {
     pub description: String,
     pub course_name: String,
     pub completion_date: u64,
+    pub valid_until: u64, // 0 for no expiration
     pub ipfs_hash: String, // For storing additional data off-chain
 }
 
@@ -30,6 +31,25 @@ pub struct Certificate {
     pub metadata: CertificateMetadata,
     pub issued_at: u64,
     pub status: CertificateStatus,
+}
+
+/// Verification result structure
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct VerificationResult {
+    pub is_valid: bool,
+    pub status: CertificateStatus,
+    pub message: String,
+    pub verified_at: u64,
+}
+
+/// Event for certificate verification
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CertificateVerifiedEvent {
+    pub id: String,
+    pub verifier: Address,
+    pub result: VerificationResult,
 }
 
 /// Error types for the contract


### PR DESCRIPTION
## Summary
This Pull Request implements the **Certificate Verification Contract** as requested in Issue #12. It introduces robust logic to verify certificate authenticity, check for expiration, validate issuer status, and track verification history on-chain.

## Changes
- **New Module**: [backend/src/certificate_verification.rs](cci:7://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/certificate_verification.rs:0:0-0:0)
  - Implements [verify_certificate](cci:1://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/certificate_verification.rs:6:4-72:5) with detailed checks for:
    - **Existence**: Ensures the certificate is valid and stored.
    - **Revocation**: Checks if the certificate has been revoked.
    - **Expiration**: Validates against the `valid_until` timestamp.
    - **Issuer Authorization**: Confirms the issuer is still authorized.
  - Implements [record_verification](cci:1://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/certificate_verification.rs:74:4-85:5) to store verification attempts on-chain.
  - Implements [get_verification_history](cci:1://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/certificate_verification.rs:95:4-102:5) to retrieve past verifications.

- **Data Models** ([backend/src/types.rs](cci:7://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/types.rs:0:0-0:0)):
  - Added `valid_until` field to [CertificateMetadata](cci:2://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/types.rs:14:0-21:1).
  - Added [VerificationResult](cci:2://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/types.rs:38:0-43:1) struct to return detailed status.
  - Added [CertificateVerifiedEvent](cci:2://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/types.rs:48:0-52:1) for on-chain logging.

- **Integration**:
  - Registered the new `certificate_verification` module in [lib.rs](cci:7://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/lib.rs:0:0-0:0).
  - Updated `DataKey` in [certificate_issuance.rs](cci:7://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/certificate_issuance.rs:0:0-0:0) to support verification history storage.

## Testing
- Added comprehensive unit tests in [backend/src/test.rs](cci:7://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/test.rs:0:0-0:0) covering:
  - Expiration logic ([test_verify_certificate_expiration](cci:1://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/test.rs:423:0-460:1)).
  - Verification history tracking ([test_verification_history](cci:1://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/test.rs:462:0-496:1)).
  - Issuer invalidation.

## Notes
- The verification logic now returns a detailed [VerificationResult](cci:2://file:///Users/macbookpro/Desktop/works/drips/StellarCert/backend/src/types.rs:38:0-43:1) struct instead of a simple boolean.
- Certificates with `valid_until: 0` are considered to never expire.

closes #12 