### PR TITLE
  feat(search): add Elasticsearch full-text search module for certifi…

### DIFF
--- a/backend/src/modules/search/constants/index.constants.ts
+++ b/backend/src/modules/search/constants/index.constants.ts
@@ -1,0 +1,31 @@
+export const CERTIFICATE_INDEX = 'certificates';
+
+export const CERTIFICATE_INDEX_CONFIG = {
+  settings: {
+    number_of_shards: 1,
+    number_of_replicas: 1,
+    analysis: {
+      analyzer: {
+        autocomplete_analyzer: {
+          type: 'custom',
+          tokenizer: 'standard',
+          filter: ['lowercase', 'asciifolding'],
+        },
+      },
+    },
+  },
+  mappings: {
+    properties: {
+      id: { type: 'keyword' },
+      recipientName: { type: 'text', analyzer: 'autocomplete_analyzer' },
+      recipientEmail: { type: 'keyword' },
+      issuerName: { type: 'text', analyzer: 'autocomplete_analyzer' },
+      issuerId: { type: 'keyword' },
+      title: { type: 'text', analyzer: 'autocomplete_analyzer' },
+      description: { type: 'text' },
+      status: { type: 'keyword' },
+      issuedAt: { type: 'date' },
+      expiresAt: { type: 'date' },
+    },
+  },
+};

--- a/backend/src/modules/search/dto/search-query.dto.ts
+++ b/backend/src/modules/search/dto/search-query.dto.ts
@@ -1,0 +1,37 @@
+import { IsOptional, IsString, IsInt, Min, Max, IsIn, IsDateString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class SearchQueryDto {
+  @IsOptional()
+  @IsString()
+  q?: string;
+
+  @IsOptional()
+  @IsString()
+  issuerId?: string;
+
+  @IsOptional()
+  @IsIn(['active', 'revoked', 'expired'])
+  status?: string;
+
+  @IsOptional()
+  @IsDateString()
+  from?: string;
+
+  @IsOptional()
+  @IsDateString()
+  to?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/backend/src/modules/search/interfaces/search.interface.ts
+++ b/backend/src/modules/search/interfaces/search.interface.ts
@@ -1,0 +1,28 @@
+export interface CertificateDocument {
+  id: string;
+  recipientName: string;
+  recipientEmail: string;
+  issuerName: string;
+  issuerId: string;
+  title: string;
+  description?: string;
+  status: string;
+  issuedAt: string;
+  expiresAt?: string;
+}
+
+export interface FacetBucket {
+  key: string;
+  count: number;
+}
+
+export interface SearchResult {
+  total: number;
+  page: number;
+  limit: number;
+  hits: CertificateDocument[];
+  facets: {
+    statuses: FacetBucket[];
+    issuers: FacetBucket[];
+  };
+}

--- a/backend/src/modules/search/providers/elasticsearch.provider.ts
+++ b/backend/src/modules/search/providers/elasticsearch.provider.ts
@@ -1,0 +1,18 @@
+import { Client } from '@elastic/elasticsearch';
+
+export const ELASTICSEARCH_CLIENT = 'ELASTICSEARCH_CLIENT';
+
+export const ElasticsearchProvider = {
+  provide: ELASTICSEARCH_CLIENT,
+  useFactory: () =>
+    new Client({
+      node: process.env.ELASTICSEARCH_URL ?? 'http://localhost:9200',
+      auth:
+        process.env.ELASTICSEARCH_USERNAME
+          ? {
+              username: process.env.ELASTICSEARCH_USERNAME,
+              password: process.env.ELASTICSEARCH_PASSWORD ?? '',
+            }
+          : undefined,
+    }),
+};

--- a/backend/src/modules/search/reindex.service.ts
+++ b/backend/src/modules/search/reindex.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Certificate } from '../certificates/entities/certificate.entity';
+import { SearchService } from './search.service';
+import { CertificateDocument } from './interfaces/search.interface';
+
+@Injectable()
+export class ReindexService {
+  private readonly logger = new Logger(ReindexService.name);
+
+  constructor(
+    @InjectRepository(Certificate)
+    private readonly certificateRepo: Repository<Certificate>,
+    private readonly searchService: SearchService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async scheduledReindex() {
+    this.logger.log('Scheduled re-index started');
+    await this.reindex();
+  }
+
+  async reindex(): Promise<{ indexed: number }> {
+    const certificates = await this.certificateRepo.find({
+      relations: ['issuer', 'recipient'],
+    });
+
+    const docs: CertificateDocument[] = certificates.map((cert) =>
+      this.toDocument(cert),
+    );
+
+    await this.searchService.dropAndRecreateIndex();
+    await this.searchService.bulkIndex(docs);
+
+    this.logger.log(`Re-indexed ${docs.length} certificates`);
+    return { indexed: docs.length };
+  }
+
+  private toDocument(cert: Certificate): CertificateDocument {
+    return {
+      id: cert.id,
+      recipientName: cert.recipientName ?? cert.recipient?.name ?? '',
+      recipientEmail: cert.recipientEmail ?? cert.recipient?.email ?? '',
+      issuerName: cert.issuer?.name ?? '',
+      issuerId: cert.issuerId ?? cert.issuer?.id ?? '',
+      title: cert.title ?? '',
+      description: cert.description ?? '',
+      status: cert.status ?? 'active',
+      issuedAt: cert.issuedAt?.toISOString() ?? new Date().toISOString(),
+      expiresAt: cert.expiresAt?.toISOString(),
+    };
+  }
+}

--- a/backend/src/modules/search/search.controller.ts
+++ b/backend/src/modules/search/search.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Post, Query, HttpCode, HttpStatus } from '@nestjs/common';
+import { SearchService } from './search.service';
+import { ReindexService } from './reindex.service';
+import { SearchQueryDto } from './dto/search-query.dto';
+
+@Controller('search')
+export class SearchController {
+  constructor(
+    private readonly searchService: SearchService,
+    private readonly reindexService: ReindexService,
+  ) {}
+
+  @Get('certificates')
+  search(@Query() query: SearchQueryDto) {
+    return this.searchService.search(query);
+  }
+
+  @Post('reindex')
+  @HttpCode(HttpStatus.OK)
+  reindex() {
+    return this.reindexService.reindex();
+  }
+}

--- a/backend/src/modules/search/search.module.ts
+++ b/backend/src/modules/search/search.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
+import { Certificate } from '../certificates/entities/certificate.entity';
+import { ElasticsearchProvider } from './providers/elasticsearch.provider';
+import { SearchService } from './search.service';
+import { ReindexService } from './reindex.service';
+import { SearchController } from './search.controller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Certificate]),
+    ScheduleModule.forRoot(),
+  ],
+  providers: [ElasticsearchProvider, SearchService, ReindexService],
+  controllers: [SearchController],
+  exports: [SearchService],
+})
+export class SearchModule {}

--- a/backend/src/modules/search/search.service.ts
+++ b/backend/src/modules/search/search.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, Inject, OnModuleInit, Logger } from '@nestjs/common';
+import { Client } from '@elastic/elasticsearch';
+import { ELASTICSEARCH_CLIENT } from './providers/elasticsearch.provider';
+import { CERTIFICATE_INDEX, CERTIFICATE_INDEX_CONFIG } from './constants/index.constants';
+import { SearchQueryDto } from './dto/search-query.dto';
+import { CertificateDocument, SearchResult } from './interfaces/search.interface';
+
+@Injectable()
+export class SearchService implements OnModuleInit {
+  private readonly logger = new Logger(SearchService.name);
+
+  constructor(@Inject(ELASTICSEARCH_CLIENT) private readonly es: Client) {}
+
+  async onModuleInit() {
+    await this.ensureIndex();
+  }
+
+  async ensureIndex() {
+    const exists = await this.es.indices.exists({ index: CERTIFICATE_INDEX });
+    if (!exists) {
+      await this.es.indices.create({
+        index: CERTIFICATE_INDEX,
+        ...CERTIFICATE_INDEX_CONFIG,
+      });
+      this.logger.log(`Index "${CERTIFICATE_INDEX}" created`);
+    }
+  }
+
+  async indexCertificate(doc: CertificateDocument) {
+    await this.es.index({
+      index: CERTIFICATE_INDEX,
+      id: doc.id,
+      document: doc,
+      refresh: true,
+    });
+  }
+
+  async bulkIndex(docs: CertificateDocument[]) {
+    if (!docs.length) return;
+
+    const operations = docs.flatMap((doc) => [
+      { index: { _index: CERTIFICATE_INDEX, _id: doc.id } },
+      doc,
+    ]);
+
+    const response = await this.es.bulk({ operations, refresh: true });
+
+    if (response.errors) {
+      const failed = response.items.filter((i) => i.index?.error);
+      this.logger.error(`Bulk index errors: ${failed.length} failed`);
+    }
+  }
+
+  async deleteCertificate(id: string) {
+    await this.es.delete({ index: CERTIFICATE_INDEX, id, refresh: true });
+  }
+
+  async search(query: SearchQueryDto): Promise<SearchResult> {
+    const { q, issuerId, status, from, to, page = 1, limit = 20 } = query;
+    const offset = (page - 1) * limit;
+
+    const must: object[] = [];
+    const filter: object[] = [];
+
+    if (q) {
+      must.push({
+        multi_match: {
+          query: q,
+          fields: ['recipientName^3', 'issuerName^2', 'title^2', 'description', 'recipientEmail'],
+          fuzziness: 'AUTO',
+          prefix_length: 1,
+          operator: 'or',
+        },
+      });
+    } else {
+      must.push({ match_all: {} });
+    }
+
+    if (issuerId) filter.push({ term: { issuerId } });
+    if (status) filter.push({ term: { status } });
+
+    if (from || to) {
+      filter.push({
+        range: {
+          issuedAt: {
+            ...(from && { gte: from }),
+            ...(to && { lte: to }),
+          },
+        },
+      });
+    }
+
+    const response = await this.es.search({
+      index: CERTIFICATE_INDEX,
+      from: offset,
+      size: limit,
+      query: { bool: { must, filter } },
+      aggregations: {
+        statuses: { terms: { field: 'status', size: 10 } },
+        issuers: { terms: { field: 'issuerId', size: 20 } },
+      },
+    });
+
+    const total =
+      typeof response.hits.total === 'number'
+        ? response.hits.total
+        : (response.hits.total as { value: number })?.value ?? 0;
+
+    const hits = response.hits.hits.map((h) => h._source as CertificateDocument);
+
+    const aggs = response.aggregations as Record<string, { buckets: { key: string; doc_count: number }[] }>;
+
+    return {
+      total,
+      page,
+      limit,
+      hits,
+      facets: {
+        statuses: aggs?.statuses?.buckets?.map((b) => ({ key: b.key, count: b.doc_count })) ?? [],
+        issuers: aggs?.issuers?.buckets?.map((b) => ({ key: b.key, count: b.doc_count })) ?? [],
+      },
+    };
+  }
+
+  async dropAndRecreateIndex() {
+    await this.es.indices.delete({ index: CERTIFICATE_INDEX, ignore_unavailable: true });
+    await this.ensureIndex();
+  }
+}


### PR DESCRIPTION
## Summary
  - Integrate Elasticsearch for fast full-text search across certificate data
  - Support fuzzy matching and faceted filtering by status, issuer, and date range
  - Expose `GET /search/certificates` and `POST /search/reindex` endpoints
  - Nightly cron job auto-reindexes all certificates at midnight

closes #74 