### PR TITLE
feat(export): add certificate export service

### DIFF
--- a/backend/src/modules/export/dto/create-export.dto.ts
+++ b/backend/src/modules/export/dto/create-export.dto.ts
@@ -1,0 +1,26 @@
+import { IsEmail, IsIn, IsOptional, IsString, IsDateString } from 'class-validator';
+
+export class CreateExportDto {
+  @IsEmail()
+  requesterEmail: string;
+
+  @IsOptional()
+  @IsIn(['pdf', 'csv', 'json'])
+  format?: 'pdf' | 'csv' | 'json' = 'csv';
+
+  @IsOptional()
+  @IsIn(['active', 'revoked', 'expired'])
+  status?: string;
+
+  @IsOptional()
+  @IsDateString()
+  from?: string;
+
+  @IsOptional()
+  @IsDateString()
+  to?: string;
+
+  @IsOptional()
+  @IsString()
+  issuerId?: string;
+}

--- a/backend/src/modules/export/entities/export-job.entity.ts
+++ b/backend/src/modules/export/entities/export-job.entity.ts
@@ -1,0 +1,59 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export type ExportFormat = 'pdf' | 'csv' | 'json';
+export type ExportStatus = 'pending' | 'processing' | 'completed' | 'failed';
+export type ExportType = 'single' | 'bulk';
+
+@Entity('export_jobs')
+export class ExportJob {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  requesterEmail: string;
+
+  @Column({ nullable: true })
+  certificateId?: string;
+
+  @Column({ type: 'enum', enum: ['pdf', 'csv', 'json'] })
+  format: ExportFormat;
+
+  @Column({ type: 'enum', enum: ['single', 'bulk'] })
+  type: ExportType;
+
+  @Column({
+    type: 'enum',
+    enum: ['pending', 'processing', 'completed', 'failed'],
+    default: 'pending',
+  })
+  status: ExportStatus;
+
+  @Column({ type: 'jsonb', nullable: true })
+  filters?: {
+    status?: string;
+    from?: string;
+    to?: string;
+    issuerId?: string;
+  };
+
+  @Column({ nullable: true })
+  filePath?: string;
+
+  @Column({ type: 'text', nullable: true })
+  errorMessage?: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  completedAt?: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/modules/export/export.controller.ts
+++ b/backend/src/modules/export/export.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Param,
+  Query,
+  Body,
+  Res,
+  StreamableFile,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { Response } from 'express';
+import * as fs from 'fs';
+import { ExportService } from './export.service';
+import { CreateExportDto } from './dto/create-export.dto';
+
+const MIME_TYPES: Record<string, string> = {
+  pdf: 'application/pdf',
+  csv: 'text/csv',
+  json: 'application/json',
+};
+
+@Controller('export')
+export class ExportController {
+  constructor(private readonly exportService: ExportService) {}
+
+  @Post('certificate/:id')
+  @HttpCode(HttpStatus.ACCEPTED)
+  exportSingle(@Param('id') id: string, @Body() dto: CreateExportDto) {
+    return this.exportService.createSingleExport(id, dto);
+  }
+
+  @Post('bulk')
+  @HttpCode(HttpStatus.ACCEPTED)
+  exportBulk(@Body() dto: CreateExportDto) {
+    return this.exportService.createBulkExport(dto);
+  }
+
+  @Get('jobs/:id')
+  getJobStatus(@Param('id') id: string) {
+    return this.exportService.getJobStatus(id);
+  }
+
+  @Get('history')
+  getHistory(@Query('email') email: string) {
+    return this.exportService.getHistory(email);
+  }
+
+  @Get('download/:id')
+  async download(
+    @Param('id') id: string,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<StreamableFile> {
+    const { filePath, format } = await this.exportService.getFileForDownload(id);
+
+    res.set({
+      'Content-Type': MIME_TYPES[format] ?? 'application/octet-stream',
+      'Content-Disposition': `attachment; filename="stellarcert-export.${format}"`,
+    });
+
+    return new StreamableFile(fs.createReadStream(filePath));
+  }
+}

--- a/backend/src/modules/export/export.module.ts
+++ b/backend/src/modules/export/export.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bull';
+import { Certificate } from '../certificates/entities/certificate.entity';
+import { ExportJob } from './entities/export-job.entity';
+import { ExportService } from './export.service';
+import { ExportController } from './export.controller';
+import { ExportProcessor, EXPORT_QUEUE } from './processors/export.processor';
+import { PdfService } from './services/pdf.service';
+import { CsvService } from './services/csv.service';
+import { ExportMailService } from './services/export-mail.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([ExportJob, Certificate]),
+    BullModule.registerQueue({ name: EXPORT_QUEUE }),
+  ],
+  providers: [ExportService, ExportProcessor, PdfService, CsvService, ExportMailService],
+  controllers: [ExportController],
+  exports: [ExportService],
+})
+export class ExportModule {}

--- a/backend/src/modules/export/export.service.ts
+++ b/backend/src/modules/export/export.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { InjectQueue } from '@nestjs/bull';
+import { Repository } from 'typeorm';
+import { Queue } from 'bull';
+import * as fs from 'fs';
+import { ExportJob } from './entities/export-job.entity';
+import { CreateExportDto } from './dto/create-export.dto';
+import { EXPORT_QUEUE } from './processors/export.processor';
+
+@Injectable()
+export class ExportService {
+  constructor(
+    @InjectRepository(ExportJob)
+    private readonly exportJobRepo: Repository<ExportJob>,
+    @InjectQueue(EXPORT_QUEUE)
+    private readonly exportQueue: Queue,
+  ) {}
+
+  async createSingleExport(certificateId: string, dto: CreateExportDto) {
+    const job = await this.exportJobRepo.save(
+      this.exportJobRepo.create({
+        requesterEmail: dto.requesterEmail,
+        format: 'pdf',
+        type: 'single',
+        certificateId,
+        status: 'pending',
+      }),
+    );
+
+    await this.exportQueue.add('generate', { jobId: job.id });
+    return { jobId: job.id, status: job.status };
+  }
+
+  async createBulkExport(dto: CreateExportDto) {
+    const job = await this.exportJobRepo.save(
+      this.exportJobRepo.create({
+        requesterEmail: dto.requesterEmail,
+        format: dto.format ?? 'csv',
+        type: 'bulk',
+        status: 'pending',
+        filters: {
+          status: dto.status,
+          from: dto.from,
+          to: dto.to,
+          issuerId: dto.issuerId,
+        },
+      }),
+    );
+
+    await this.exportQueue.add('generate', { jobId: job.id });
+    return { jobId: job.id, status: job.status };
+  }
+
+  async getJobStatus(jobId: string) {
+    const job = await this.exportJobRepo.findOne({ where: { id: jobId } });
+    if (!job) throw new NotFoundException('Export job not found');
+    return job;
+  }
+
+  async getHistory(requesterEmail: string) {
+    return this.exportJobRepo.find({
+      where: { requesterEmail },
+      order: { createdAt: 'DESC' },
+      take: 50,
+    });
+  }
+
+  async getFileForDownload(jobId: string) {
+    const job = await this.exportJobRepo.findOne({ where: { id: jobId } });
+
+    if (!job || job.status !== 'completed' || !job.filePath) {
+      throw new NotFoundException('File not available');
+    }
+
+    if (!fs.existsSync(job.filePath)) {
+      throw new NotFoundException('File no longer exists on server');
+    }
+
+    return { filePath: job.filePath, format: job.format };
+  }
+}

--- a/backend/src/modules/export/processors/export.processor.ts
+++ b/backend/src/modules/export/processors/export.processor.ts
@@ -1,0 +1,97 @@
+import { Processor, Process } from '@nestjs/bull';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import * as fs from 'fs';
+import * as path from 'path';
+import { ExportJob } from '../entities/export-job.entity';
+import { Certificate } from '../../certificates/entities/certificate.entity';
+import { PdfService } from '../services/pdf.service';
+import { CsvService } from '../services/csv.service';
+import { ExportMailService } from '../services/export-mail.service';
+
+export const EXPORT_QUEUE = 'export';
+
+@Processor(EXPORT_QUEUE)
+export class ExportProcessor {
+  private readonly logger = new Logger(ExportProcessor.name);
+  private readonly outputDir = path.join(process.cwd(), 'uploads', 'exports');
+
+  constructor(
+    @InjectRepository(ExportJob)
+    private readonly exportJobRepo: Repository<ExportJob>,
+    @InjectRepository(Certificate)
+    private readonly certificateRepo: Repository<Certificate>,
+    private readonly pdfService: PdfService,
+    private readonly csvService: CsvService,
+    private readonly mailService: ExportMailService,
+  ) {
+    fs.mkdirSync(this.outputDir, { recursive: true });
+  }
+
+  @Process('generate')
+  async handleGenerate(job: Job<{ jobId: string }>) {
+    const exportJob = await this.exportJobRepo.findOne({ where: { id: job.data.jobId } });
+    if (!exportJob) return;
+
+    await this.exportJobRepo.update(exportJob.id, { status: 'processing' });
+
+    try {
+      const certificates = await this.fetchCertificates(exportJob);
+
+      const fileName = `export-${exportJob.id}.${exportJob.format}`;
+      const filePath = path.join(this.outputDir, fileName);
+
+      if (exportJob.format === 'pdf') {
+        const buffer = await this.pdfService.generateCertificate(certificates[0]);
+        fs.writeFileSync(filePath, buffer);
+      } else if (exportJob.format === 'csv') {
+        fs.writeFileSync(filePath, this.csvService.generateCsv(certificates));
+      } else {
+        fs.writeFileSync(filePath, this.csvService.generateJson(certificates));
+      }
+
+      await this.exportJobRepo.update(exportJob.id, {
+        status: 'completed',
+        filePath,
+        completedAt: new Date(),
+      });
+
+      const downloadUrl = `${process.env.APP_URL}/export/download/${exportJob.id}`;
+      await this.mailService.sendDownloadLink(exportJob.requesterEmail, downloadUrl, exportJob.format);
+
+      this.logger.log(`Export job ${exportJob.id} completed (${certificates.length} records)`);
+    } catch (err) {
+      this.logger.error(`Export job ${exportJob.id} failed: ${err.message}`);
+      await this.exportJobRepo.update(exportJob.id, {
+        status: 'failed',
+        errorMessage: err.message,
+      });
+    }
+  }
+
+  private async fetchCertificates(exportJob: ExportJob): Promise<Certificate[]> {
+    if (exportJob.type === 'single' && exportJob.certificateId) {
+      const cert = await this.certificateRepo.findOne({
+        where: { id: exportJob.certificateId },
+        relations: ['issuer', 'recipient'],
+      });
+      return cert ? [cert] : [];
+    }
+
+    const qb = this.certificateRepo
+      .createQueryBuilder('cert')
+      .leftJoinAndSelect('cert.issuer', 'issuer')
+      .leftJoinAndSelect('cert.recipient', 'recipient');
+
+    const { status, issuerId, from, to } = exportJob.filters ?? {};
+
+    if (status) qb.andWhere('cert.status = :status', { status });
+    if (issuerId) qb.andWhere('cert.issuerId = :issuerId', { issuerId });
+    if (from) qb.andWhere('cert.issuedAt >= :from', { from });
+    if (to) qb.andWhere('cert.issuedAt <= :to', { to });
+
+    return qb.getMany();
+  }
+}

--- a/backend/src/modules/export/services/csv.service.ts
+++ b/backend/src/modules/export/services/csv.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+
+const CSV_HEADERS = [
+  'id',
+  'recipientName',
+  'recipientEmail',
+  'issuerName',
+  'title',
+  'status',
+  'issuedAt',
+  'expiresAt',
+];
+
+@Injectable()
+export class CsvService {
+  generateCsv(certs: any[]): Buffer {
+    const escape = (val: any) => `"${String(val ?? '').replace(/"/g, '""')}"`;
+
+    const rows = certs.map((c) =>
+      CSV_HEADERS.map((h) => {
+        if (h === 'issuerName') return escape(c.issuer?.name ?? c.issuerId ?? '');
+        if (h === 'recipientName') return escape(c.recipient?.name ?? c.recipientName ?? '');
+        if (h === 'recipientEmail') return escape(c.recipient?.email ?? c.recipientEmail ?? '');
+        return escape(c[h]);
+      }).join(','),
+    );
+
+    return Buffer.from([CSV_HEADERS.join(','), ...rows].join('\n'), 'utf-8');
+  }
+
+  generateJson(certs: any[]): Buffer {
+    const data = certs.map((c) => ({
+      id: c.id,
+      recipientName: c.recipient?.name ?? c.recipientName ?? '',
+      recipientEmail: c.recipient?.email ?? c.recipientEmail ?? '',
+      issuerName: c.issuer?.name ?? c.issuerId ?? '',
+      title: c.title ?? '',
+      status: c.status ?? '',
+      issuedAt: c.issuedAt ?? '',
+      expiresAt: c.expiresAt ?? null,
+    }));
+
+    return Buffer.from(JSON.stringify(data, null, 2), 'utf-8');
+  }
+}

--- a/backend/src/modules/export/services/export-mail.service.ts
+++ b/backend/src/modules/export/services/export-mail.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as nodemailer from 'nodemailer';
+import { ExportFormat } from '../entities/export-job.entity';
+
+@Injectable()
+export class ExportMailService {
+  private readonly logger = new Logger(ExportMailService.name);
+
+  private readonly transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT ?? 587),
+    secure: process.env.SMTP_SECURE === 'true',
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+
+  async sendDownloadLink(to: string, downloadUrl: string, format: ExportFormat) {
+    try {
+      await this.transporter.sendMail({
+        from: process.env.SMTP_FROM ?? 'noreply@stellarcert.com',
+        to,
+        subject: 'Your Certificate Export is Ready',
+        html: `
+          <p>Your certificate export (<strong>${format.toUpperCase()}</strong>) has been generated.</p>
+          <p>
+            <a href="${downloadUrl}" style="padding:10px 20px;background:#1a1a2e;color:#fff;text-decoration:none;border-radius:4px;">
+              Download Export
+            </a>
+          </p>
+          <p style="color:#888;font-size:12px;">This link will be available as long as the file exists on the server.</p>
+        `,
+      });
+    } catch (err) {
+      this.logger.error(`Failed to send export email to ${to}: ${err.message}`);
+    }
+  }
+}

--- a/backend/src/modules/export/services/pdf.service.ts
+++ b/backend/src/modules/export/services/pdf.service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@nestjs/common';
+import * as PDFDocument from 'pdfkit';
+
+@Injectable()
+export class PdfService {
+  generateCertificate(cert: any): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const doc = new PDFDocument({ size: 'A4', margin: 72 });
+      const chunks: Buffer[] = [];
+
+      doc.on('data', (chunk) => chunks.push(chunk));
+      doc.on('end', () => resolve(Buffer.concat(chunks)));
+      doc.on('error', reject);
+
+      doc
+        .rect(36, 36, doc.page.width - 72, doc.page.height - 72)
+        .stroke('#c0a060');
+
+      doc.moveDown(3);
+
+      doc
+        .fontSize(30)
+        .font('Helvetica-Bold')
+        .fillColor('#1a1a2e')
+        .text('Certificate of Achievement', { align: 'center' });
+
+      doc.moveDown(1.5);
+
+      doc
+        .fontSize(14)
+        .font('Helvetica')
+        .fillColor('#333333')
+        .text('This certifies that', { align: 'center' });
+
+      doc.moveDown(0.5);
+
+      doc
+        .fontSize(22)
+        .font('Helvetica-Bold')
+        .fillColor('#1a1a2e')
+        .text(cert.recipientName ?? cert.recipient?.name ?? 'N/A', { align: 'center' });
+
+      doc.moveDown(0.5);
+
+      doc
+        .fontSize(14)
+        .font('Helvetica')
+        .fillColor('#333333')
+        .text(`has successfully completed`, { align: 'center' });
+
+      doc.moveDown(0.5);
+
+      doc
+        .fontSize(18)
+        .font('Helvetica-Bold')
+        .text(cert.title ?? 'N/A', { align: 'center' });
+
+      doc.moveDown(1.5);
+
+      doc
+        .fontSize(11)
+        .font('Helvetica')
+        .fillColor('#555555')
+        .text(`Certificate ID: ${cert.id}`, { align: 'center' })
+        .text(`Issued by: ${cert.issuer?.name ?? cert.issuerId ?? 'N/A'}`, { align: 'center' })
+        .text(`Date Issued: ${new Date(cert.issuedAt).toLocaleDateString()}`, { align: 'center' });
+
+      if (cert.expiresAt) {
+        doc.text(`Expiry Date: ${new Date(cert.expiresAt).toLocaleDateString()}`, { align: 'center' });
+      }
+
+      doc.moveDown(0.8);
+
+      doc
+        .fontSize(10)
+        .fillColor('#888888')
+        .text(`Status: ${cert.status ?? 'active'}`, { align: 'center' });
+
+      doc.end();
+    });
+  }
+}


### PR DESCRIPTION
 ## Summary
  - Add async export service supporting PDF (single), CSV, and JSON (bulk) formats
  - Track all export jobs in `export_jobs` table with status and history per user
  - Filter bulk exports by status, issuer, and date range via query builder
  - Send email with download link upon job completion via nodemailer
  - Process large exports asynchronously through Bull queue
  
  closes #69 