### PR TITLE
feat: Add QR code scanner and share buttons to certificate verification page

### DIFF
--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -210,22 +210,28 @@ export const verifyCertificate = async (serialNumber: string): Promise<Verificat
         const certificate = dummyData.certificates.find(cert => cert.serialNumber === serialNumber);
         const result: VerificationResult = certificate ? {
             isValid: certificate.status === "active",
+            status: certificate.status === "active" ? "valid" : "revoked",
             certificate,
             verificationDate: new Date().toISOString(),
+            verifiedAt: new Date().toISOString(),
             message: certificate.status === "active"
                 ? "Certificate is valid and active"
-                : "Certificate has been revoked."
+                : "Certificate has been revoked.",
+            verificationId: `ver_${Date.now()}`
         } : {
             isValid: false,
+            status: "not_found",
             verificationDate: new Date().toISOString(),
-            message: "Certificate not found"
+            verifiedAt: new Date().toISOString(),
+            message: "Certificate not found",
+            verificationId: `ver_${Date.now()}`
         };
         console.log("Dummy Verification:", result);
         return result;
     }
 
     try {
-        return await apiClient<VerificationResult>(`/certificates/verify/${serialNumber}`);
+        return await apiClient<VerificationResult>(`/certificates/${serialNumber}/verify`);
     } catch (error) {
         return handleError(error, "verifyCertificate");
     }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -73,14 +73,17 @@ export interface CreateCertificateData {
  */
 export interface VerificationResult {
   isValid: boolean;
+  status?: 'valid' | 'revoked' | 'expired' | 'not_found';
   certificate?: Certificate;
-  verificationDate: string;
+  verificationDate?: string;
+  verifiedAt?: string;
   stellarProof?: {
     txHash: string;
     ledger: number;
     timestamp: string;
   };
   message?: string;
+  verificationId?: string;
 }
 
 /**


### PR DESCRIPTION
closes #60
# Summary
- Add QR code scanning functionality using html5-qrcode library
- Add share buttons to copy verification link and share result
- Update API endpoint to match backend (/certificates/:id/verify)
- Update VerificationResult type to include backend fields
- Update dummy data to match new type structure