### PR TITLE
feat: Added  Password Visibility to the login form

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { LogIn, UserPlus, Shield } from "lucide-react";
+import { LogIn, UserPlus, Shield, Eye, EyeOff } from "lucide-react";
 import { authApi, UserRole } from "../api";
 
 const Login = () => {
     const navigate = useNavigate();
     const [isLogin, setIsLogin] = useState(true);
+    const [showPassword, setShowPassword] = useState(false);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
@@ -128,15 +129,28 @@ const Login = () => {
                         <label className="block text-sm font-medium text-gray-700 mb-1">
                             Password
                         </label>
-                        <input
-                            type="password"
-                            value={formData.password}
-                            onChange={(e) =>
-                                setFormData({ ...formData, password: e.target.value })
-                            }
-                            className="w-full px-4 py-2 border rounded-md focus:ring-blue-500 focus:border-blue-500"
-                            required
-                        />
+                        <div className="relative">
+                            <input
+                                type={showPassword ? "text" : "password"}
+                                value={formData.password}
+                                onChange={(e) =>
+                                    setFormData({ ...formData, password: e.target.value })
+                                }
+                                className="w-full px-4 py-2 border rounded-md focus:ring-blue-500 focus:border-blue-500 pr-10"
+                                required
+                            />
+                            <button
+                                type="button"
+                                onClick={() => setShowPassword(!showPassword)}
+                                className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600"
+                            >
+                                {showPassword ? (
+                                    <EyeOff className="h-5 w-5" />
+                                ) : (
+                                    <Eye className="h-5 w-5" />
+                                )}
+                            </button>
+                        </div>
                     </div>
 
                     {!isLogin && (


### PR DESCRIPTION
close: #160 

## Description
The password field in the login and registration forms previously lacked a visibility toggle, which could lead to input errors and user frustration. This PR adds a toggle button that allows users to show or hide their password.

## Changes
- Added `showPassword` state to [Login.tsx](cci:7://file:///c:/Users/HomePC/Desktop/DRIPS%20W3/StellarCert/frontend/src/pages/Login.tsx:0:0-0:0).
- Integrated `Eye` and `EyeOff` icons from `lucide-react`.
- Updated the password input JSX to wrap it in a `relative` container.
- Implemented the toggle logic to switch the input `type` between `password` and `text`.
- Added a styled toggle button with hover states.

## Verification
- [x] Verified that the password is masked by default.
- [x] Verified that clicking the toggle reveals the password.
- [x] Verified that the toggle works in both Login and Sign Up modes.

https://github.com/user-attachments/assets/3fb4a2d6-fc69-482d-841e-d3b51c57e111

