### PR TITLE
 Implement Actual Certificate Count in User Stats Endpoint

### DIFF
--- a/backend/src/modules/users/repositories/user.repository.ts
+++ b/backend/src/modules/users/repositories/user.repository.ts
@@ -232,4 +232,20 @@ export class UserRepository {
   async updateLastLogin(id: string): Promise<void> {
     await this.repository.update(id, { lastLoginAt: new Date() });
   }
+
+  async getPerUserCertificateCounts(): Promise<Record<string, number>> {
+    const rawData = await this.repository
+      .createQueryBuilder('user')
+      .leftJoin('certificates', 'cert', 'cert."issuerId" = user.id')
+      .select('user.id', 'userId')
+      .addSelect('COUNT(cert.id)', 'count')
+      .groupBy('user.id')
+      .getRawMany();
+
+    const result: Record<string, number> = {};
+    rawData.forEach(row => {
+      result[row.userId] = parseInt(row.count, 10);
+    });
+    return result;
+  }
 }

--- a/backend/src/modules/users/users.controller.spec.ts
+++ b/backend/src/modules/users/users.controller.spec.ts
@@ -342,6 +342,7 @@ describe('UsersController', () => {
             [UserStatus.SUSPENDED]: 5,
             [UserStatus.PENDING_VERIFICATION]: 5,
           },
+          certificateIssuanceCounts: { 'user1': 5 },
         };
 
         mockUsersService.getUserStats.mockResolvedValue(stats);

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -90,6 +90,7 @@ describe('UsersService', () => {
     resetLoginAttempts: jest.fn(),
     lockAccount: jest.fn(),
     updateLastLogin: jest.fn(),
+    getPerUserCertificateCounts: jest.fn(),
   };
 
   const mockJwtService = {
@@ -630,6 +631,7 @@ describe('UsersService', () => {
       mockUserRepository.countActive.mockResolvedValue(80);
       mockUserRepository.countByRole.mockResolvedValue(50);
       mockUserRepository.countByStatus.mockResolvedValue(60);
+      mockUserRepository.getPerUserCertificateCounts.mockResolvedValue({'user1': 5});
 
       const result = await service.getUserStats();
 
@@ -637,6 +639,8 @@ describe('UsersService', () => {
       expect(result).toHaveProperty('active');
       expect(result).toHaveProperty('byRole');
       expect(result).toHaveProperty('byStatus');
+      expect(result).toHaveProperty('certificateIssuanceCounts');
+      expect(result.certificateIssuanceCounts).toEqual({'user1': 5});
     });
   });
 });

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -793,6 +793,7 @@ export class UsersService {
     active: number;
     byRole: Record<UserRole, number>;
     byStatus: Record<UserStatus, number>;
+    certificateIssuanceCounts: Record<string, number>;
   }> {
     const [total, active, userCount, issuerCount, adminCount] =
       await Promise.all([
@@ -811,6 +812,8 @@ export class UsersService {
         this.userRepository.countByStatus(UserStatus.PENDING_VERIFICATION),
       ]);
 
+    const certificateIssuanceCounts = await this.userRepository.getPerUserCertificateCounts();
+
     return {
       total,
       active,
@@ -825,6 +828,7 @@ export class UsersService {
         [UserStatus.SUSPENDED]: suspendedStatus,
         [UserStatus.PENDING_VERIFICATION]: pendingStatus,
       },
+      certificateIssuanceCounts,
     };
   }
 


### PR DESCRIPTION
this pr successfully implements the per-user certificate issuance counts feature in the GET /users/stats endpoint.

closes #182 