### PR TITLE
fix(auth): prevent information leakage in registration error response

### DIFF
--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -72,7 +72,7 @@ export class AuthService {
       registerDto.email,
     );
     if (existingUser) {
-      throw new UnauthorizedException('User already exists');
+      throw new UnauthorizedException('Registration failed');
     }
 
     // Hash password


### PR DESCRIPTION
Backend Development

Great issue: [Security] Prevent Information Leakage in Registration Error Response

Description: AuthService.register() throws UnauthorizedException('User already exists') when an email is taken, which confirms to an attacker that the email is registered; it should return a generic response consistent with the pattern already used in UsersService.

closes #181 