### PR TITLE
feat(certificate): add @CurrentUser decorator to create and revoke endpoints

### DIFF
--- a/backend/src/modules/certificate/certificate.controller.ts
+++ b/backend/src/modules/certificate/certificate.controller.ts
@@ -22,6 +22,7 @@ import { JwtAuthGuard } from 'src/common';
 import { RolesGuard } from '../../common/guards/roles.guard';
 import { Roles } from '../../common/decorators/roles.decorator';
 import { UserRole } from '../../common/constants/roles';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { CreateCertificateDto } from './dto/create-certificate.dto';
 import { CertificateQrResponseDto } from './dto/certificate-qr-response.dto';
 
@@ -75,7 +76,11 @@ export class CertificateController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ISSUER, UserRole.ADMIN)
   @ApiOperation({ summary: 'Create new certificate' })
-  async create(@Body() dto: CreateCertificateDto) {
+  async create(
+    @Body() dto: CreateCertificateDto,
+    @CurrentUser('sub') issuerId: string,
+  ) {
+    dto.issuerId = issuerId;
     return this.certificateService.create(dto);
   }
 
@@ -83,8 +88,13 @@ export class CertificateController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ISSUER, UserRole.ADMIN)
   @ApiOperation({ summary: 'Revoke certificate' })
-  async revoke(@Param('id') id: string, @Body('reason') reason?: string) {
-    return this.certificateService.revoke(id, reason);
+  async revoke(
+    @Param('id') id: string,
+    @Body('reason') reason?: string,
+    @CurrentUser('sub') issuerId?: string,
+    @CurrentUser('role') userRole?: string,
+  ) {
+    return this.certificateService.revoke(id, reason, issuerId, userRole);
   }
 
   @Patch(':id/freeze')
@@ -110,8 +120,15 @@ export class CertificateController {
   async bulkRevoke(
     @Body('certificateIds') certificateIds: string[],
     @Body('reason') reason?: string,
+    @CurrentUser('sub') issuerId?: string,
+    @CurrentUser('role') userRole?: string,
   ) {
-    return this.certificateService.bulkRevoke(certificateIds, reason);
+    return this.certificateService.bulkRevoke(
+      certificateIds,
+      reason,
+      issuerId,
+      userRole,
+    );
   }
 
   @Get('export')

--- a/backend/src/modules/certificate/certificate.service.ts
+++ b/backend/src/modules/certificate/certificate.service.ts
@@ -1,6 +1,7 @@
 import {
   Injectable,
   ConflictException,
+  ForbiddenException,
   Logger,
   NotFoundException,
 } from '@nestjs/common';
@@ -253,8 +254,19 @@ export class CertificateService {
     return this.certificateRepository.save(certificate);
   }
 
-  async revoke(id: string, reason?: string): Promise<Certificate> {
+  async revoke(
+    id: string,
+    reason?: string,
+    issuerId?: string,
+    userRole?: string,
+  ): Promise<Certificate> {
     const certificate = await this.findOne(id);
+
+    if (userRole !== 'admin' && issuerId && certificate.issuerId !== issuerId) {
+      throw new ForbiddenException(
+        'You are not authorized to revoke this certificate',
+      );
+    }
 
     certificate.status = 'revoked';
     if (reason) {
@@ -355,6 +367,8 @@ export class CertificateService {
   async bulkRevoke(
     certificateIds: string[],
     reason?: string,
+    issuerId?: string,
+    userRole?: string,
   ): Promise<{
     revoked: Certificate[];
     failed: { id: string; error: string }[];
@@ -364,7 +378,7 @@ export class CertificateService {
 
     for (const id of certificateIds) {
       try {
-        const certificate = await this.revoke(id, reason);
+        const certificate = await this.revoke(id, reason, issuerId, userRole);
         revoked.push(certificate);
       } catch (error) {
         failed.push({

--- a/backend/src/modules/certificate/dto/create-certificate.dto.ts
+++ b/backend/src/modules/certificate/dto/create-certificate.dto.ts
@@ -9,6 +9,7 @@ import {
 import { Type } from 'class-transformer';
 
 export class CreateCertificateDto {
+  @IsOptional()
   @IsUUID()
   issuerId: string;
 


### PR DESCRIPTION
## Summary

- ** endpoint**:  is now extracted from the authenticated JWT payload ( claim) instead of the request body, preventing any issuer from impersonating another by supplying a different .
- ** /  endpoints**: The authenticated user's ID and role are now extracted from the JWT and passed to the service. ISSUER-role users can only revoke certificates they own; ADMIN users retain unrestricted access.
-  in  made optional () since it is now always set from the JWT, not the client payload.

Closes #176

## Test plan
- [ ] As an ISSUER, create a certificate — verify  is set to the authenticated user's ID regardless of any  provided in the body.
- [ ] As an ISSUER, attempt to revoke a certificate belonging to another issuer — expect 403 Forbidden.
- [ ] As an ISSUER, revoke your own certificate — expect success.
- [ ] As an ADMIN, revoke any certificate — expect success.
- [ ] As an ADMIN, create a certificate — verify  is set to the admin's JWT sub.
