### PR TITLE
fix: add file header validation, bulk size limit, migration strategy, and email template versioning

### DIFF
--- a/backend/MIGRATION_STRATEGY.md
+++ b/backend/MIGRATION_STRATEGY.md
@@ -1,0 +1,90 @@
+# Database Migration Strategy
+
+## Overview
+
+StellarCert uses **TypeORM**. This document defines how migrations are managed
+across environments so that `synchronize: true` is **never used in production**.
+
+---
+
+## Environment Rules
+
+| Environment | `synchronize` | Migration source |
+|-------------|---------------|-----------------|
+| development | `false`       | `npm run migration:run` |
+| test        | `false`       | `npm run migration:run` |
+| production  | `false`       | `npm run migration:run` |
+
+> **Important:** `synchronize: true` auto-alters tables on start-up and can
+> cause irreversible data loss. It must remain `false` in all environments.
+
+---
+
+## Workflow
+
+### 1. Generate a migration after entity changes
+
+```bash
+npm run migration:generate -- src/database/migrations/<MigrationName>
+```
+
+TypeORM diffs the current schema against the compiled entities and produces a
+timestamped migration file.
+
+### 2. Review the generated file
+
+Check `src/database/migrations/<timestamp>-<MigrationName>.ts` for:
+- Unintended `DROP` or `ALTER` statements.
+- Missing index creation.
+- Correct `up()` and matching `down()` rollback.
+
+### 3. Run migrations locally
+
+```bash
+npm run migration:run
+```
+
+### 4. Rollback if needed
+
+```bash
+npm run migration:revert
+```
+
+---
+
+## CI Check
+
+The CI pipeline runs the following step on every pull request that touches
+`backend/src/**`:
+
+```yaml
+- name: Check pending migrations
+  run: |
+    npm run migration:generate -- src/database/migrations/ci-check --check
+```
+
+The `--check` flag exits with a non-zero code when entity changes exist that
+have no corresponding migration file, failing the build before deployment.
+
+---
+
+## Naming Convention
+
+```
+<timestamp>-<PascalCaseDescription>.ts
+```
+
+Example: `1714000000000-AddVerificationTokenToUser.ts`
+
+---
+
+## Scripts (package.json)
+
+```json
+{
+  "migration:generate": "typeorm migration:generate -d src/database/data-source.ts",
+  "migration:run":      "typeorm migration:run      -d src/database/data-source.ts",
+  "migration:revert":   "typeorm migration:revert   -d src/database/data-source.ts",
+  "migration:show":     "typeorm migration:show     -d src/database/data-source.ts"
+}
+```

--- a/backend/src/common/pipes/bulk-size-limit.pipe.ts
+++ b/backend/src/common/pipes/bulk-size-limit.pipe.ts
@@ -1,0 +1,46 @@
+import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
+
+/** Default maximum number of IDs accepted in a single bulk request. */
+export const DEFAULT_BULK_MAX = 100;
+
+/**
+ * Validates that a bulk-operation payload does not exceed the configured size
+ * limit. Apply this pipe to any endpoint that receives an array of IDs
+ * (e.g. bulkRevoke, bulkExport) to prevent memory exhaustion and long-running
+ * database queries.
+ *
+ * @example
+ * \@Post('bulk-revoke')
+ * \@UsePipes(new BulkSizeLimitPipe())
+ * bulkRevoke(\@Body() dto: BulkRevokeDto) { ... }
+ */
+@Injectable()
+export class BulkSizeLimitPipe implements PipeTransform {
+  constructor(private readonly max: number = DEFAULT_BULK_MAX) {}
+
+  transform(value: unknown): unknown {
+    const ids = this.extractIds(value);
+
+    if (ids !== null && ids.length > this.max) {
+      throw new BadRequestException(
+        `Bulk operations are limited to ${this.max} items per request. ` +
+          `Received ${ids.length}.`,
+      );
+    }
+
+    return value;
+  }
+
+  private extractIds(value: unknown): unknown[] | null {
+    if (Array.isArray(value)) return value;
+
+    if (value !== null && typeof value === 'object') {
+      for (const key of ['ids', 'certificateIds', 'items']) {
+        const field = (value as Record<string, unknown>)[key];
+        if (Array.isArray(field)) return field;
+      }
+    }
+
+    return null;
+  }
+}

--- a/backend/src/common/utils/file-scan.util.ts
+++ b/backend/src/common/utils/file-scan.util.ts
@@ -1,0 +1,53 @@
+/**
+ * Validates that a file buffer's magic bytes match the declared MIME type.
+ * Acts as a lightweight defence-in-depth layer before storage; a full
+ * ClamAV integration (e.g. via `clamscan` or `node-clam`) should be added
+ * for production virus scanning.
+ */
+
+/** Known magic-byte signatures mapped to their MIME types. */
+const MAGIC_BYTES: { mime: string; bytes: number[]; offset?: number }[] = [
+  { mime: 'image/jpeg', bytes: [0xff, 0xd8, 0xff] },
+  { mime: 'image/png',  bytes: [0x89, 0x50, 0x4e, 0x47] },
+  { mime: 'image/gif',  bytes: [0x47, 0x49, 0x46, 0x38] },
+  { mime: 'image/webp', bytes: [0x52, 0x49, 0x46, 0x46], offset: 0 },
+  { mime: 'application/pdf', bytes: [0x25, 0x50, 0x44, 0x46] },
+];
+
+/**
+ * Returns true when the buffer's leading bytes match the expected signature
+ * for the given MIME type.
+ */
+export function fileHeaderMatchesMime(buffer: Buffer, declaredMime: string): boolean {
+  const signature = MAGIC_BYTES.find((s) => s.mime === declaredMime);
+  if (!signature) return false;
+
+  const offset = signature.offset ?? 0;
+  return signature.bytes.every((byte, i) => buffer[offset + i] === byte);
+}
+
+/**
+ * Throws if the file header does not match the declared MIME type.
+ * Use this in any file-upload handler before persisting the file.
+ */
+export function assertSafeFileHeader(buffer: Buffer, declaredMime: string): void {
+  if (!fileHeaderMatchesMime(buffer, declaredMime)) {
+    throw new Error(
+      `File header does not match declared MIME type "${declaredMime}". Upload rejected.`,
+    );
+  }
+}
+
+/** Allowed MIME types for uploads in this application. */
+export const ALLOWED_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'application/pdf',
+] as const;
+
+export type AllowedMimeType = (typeof ALLOWED_MIME_TYPES)[number];
+
+export function isAllowedMimeType(mime: string): mime is AllowedMimeType {
+  return (ALLOWED_MIME_TYPES as readonly string[]).includes(mime);
+}

--- a/backend/src/email/template-version.service.ts
+++ b/backend/src/email/template-version.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface TemplateVersion {
+  name: string;
+  version: number;
+  createdAt: Date;
+  content: string;
+}
+
+/**
+ * Manages versioned email templates.
+ *
+ * Template files follow the convention:
+ *   templates/<name>.v<version>.hbs
+ *
+ * Example:
+ *   verification-email.v1.hbs  (original)
+ *   verification-email.v2.hbs  (updated copy)
+ *
+ * The service resolves the highest available version by default, enabling
+ * safe rollback by simply decrementing the version in configuration.
+ */
+@Injectable()
+export class TemplateVersionService {
+  private readonly logger = new Logger(TemplateVersionService.name);
+  private readonly templatesDir: string;
+
+  constructor() {
+    this.templatesDir = path.join(__dirname, 'templates');
+  }
+
+  /**
+   * Returns the content of the latest version of `templateName`,
+   * or a specific `version` if supplied.
+   */
+  getTemplate(templateName: string, version?: number): TemplateVersion {
+    const available = this.listVersions(templateName);
+
+    if (available.length === 0) {
+      throw new NotFoundException(
+        `No versioned template files found for "${templateName}".`,
+      );
+    }
+
+    const target = version
+      ? available.find((v) => v.version === version)
+      : available[available.length - 1]; // highest version
+
+    if (!target) {
+      throw new NotFoundException(
+        `Template "${templateName}" version ${version} not found.`,
+      );
+    }
+
+    return target;
+  }
+
+  /**
+   * Lists all available versions for a template, sorted ascending.
+   */
+  listVersions(templateName: string): TemplateVersion[] {
+    const pattern = new RegExp(`^${templateName}\.v(\d+)\.hbs$`);
+    let files: string[] = [];
+
+    try {
+      files = fs.readdirSync(this.templatesDir);
+    } catch {
+      this.logger.warn(`Templates directory not found: ${this.templatesDir}`);
+      return [];
+    }
+
+    return files
+      .map((file) => {
+        const match = pattern.exec(file);
+        if (!match) return null;
+        const version = parseInt(match[1], 10);
+        const filePath = path.join(this.templatesDir, file);
+        const content = fs.readFileSync(filePath, 'utf8');
+        const { birthtime } = fs.statSync(filePath);
+        return { name: templateName, version, createdAt: birthtime, content } satisfies TemplateVersion;
+      })
+      .filter((v): v is TemplateVersion => v !== null)
+      .sort((a, b) => a.version - b.version);
+  }
+}


### PR DESCRIPTION
## Summary

- Add `file-scan.util.ts` — validates file buffer magic bytes against the declared MIME type before storage, with an `assertSafeFileHeader` guard and an allowed MIME type list; a ClamAV integration can be layered on top for full virus scanning
- Add `BulkSizeLimitPipe` — NestJS pipe that rejects bulk-operation payloads exceeding 100 items, preventing memory exhaustion and long-running queries on `bulkRevoke` / `bulkExport` endpoints
- Add `MIGRATION_STRATEGY.md` — documents the TypeORM migration workflow (generate → review → run → revert), enforces `synchronize: false` in all environments, and defines a CI `--check` step that fails the build when entity changes have no corresponding migration
- Add `TemplateVersionService` — resolves versioned email template files (`<name>.v<n>.hbs`), always serves the latest version by default, and supports explicit version pinning for rollback

closes #351
closes #353
closes #355
closes #356