### PR TITLE
fix: pagination, Stellar health check, request ID correlation, webhook retry backoff

### DIFF
--- a/backend/src/common/logging/correlation-id.middleware.ts
+++ b/backend/src/common/logging/correlation-id.middleware.ts
@@ -19,7 +19,7 @@ export class CorrelationIdMiddleware implements NestMiddleware {
     // Create context for this request
     const context: LogContext = {
       correlationId,
-      requestId: req.headers['x-request-id'] as string,
+      requestId: (req.headers['x-request-id'] as string) || this.loggingService.generateCorrelationId(),
       userId: (req as any).user?.id,
     };
 
@@ -28,7 +28,7 @@ export class CorrelationIdMiddleware implements NestMiddleware {
 
     // Add correlation ID to response headers
     res.setHeader('x-correlation-id', correlationId);
-    res.setHeader('x-request-id', context.requestId || '');
+    res.setHeader('x-request-id', context.requestId as string);
 
     // Log request
     this.loggingService.log(

--- a/backend/src/modules/certificate/certificate.controller.ts
+++ b/backend/src/modules/certificate/certificate.controller.ts
@@ -188,6 +188,21 @@ export class CertificateController {
     );
   }
 
+  @Get('user/:userId')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.ISSUER, UserRole.USER)
+  @ApiOperation({ summary: 'List all certificates for a user with pagination' })
+  @ApiParam({ name: 'userId', description: 'User UUID' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  async getUserCertificates(
+    @Param('userId', ParseUUIDPipe) userId: string,
+    @Query('page') page = 1,
+    @Query('limit') limit = 10,
+  ) {
+    return this.certificateService.getUserCertificates(userId, +page, +limit);
+  }
+
   // ─── Single Certificate ───────────────────────────────────────────────────────
 
   @Get(':id/qr')

--- a/backend/src/modules/certificate/certificate.service.ts
+++ b/backend/src/modules/certificate/certificate.service.ts
@@ -542,6 +542,14 @@ export class CertificateService {
     return certificate;
   }
 
+  async getUserCertificates(
+    userId: string,
+    page = 1,
+    limit = 10,
+  ): Promise<PaginatedCertificates> {
+    return this.certRepo.findByUserId(userId, page, limit);
+  }
+
   async getCertificatesByRecipient(
     email: string,
     page = 1,

--- a/backend/src/modules/certificate/repositories/certificate.repository.ts
+++ b/backend/src/modules/certificate/repositories/certificate.repository.ts
@@ -91,6 +91,23 @@ export class CertificateRepository {
     return { data, total, page, limit, totalPages: Math.ceil(total / limit) };
   }
 
+  async findByUserId(
+    userId: string,
+    page = 1,
+    limit = 10,
+  ): Promise<PaginatedCertificates> {
+    const [data, total] = await this.repo
+      .createQueryBuilder('cert')
+      .leftJoinAndSelect('cert.issuer', 'issuer')
+      .innerJoin('users', 'u', 'u.email = cert.recipientEmail')
+      .where('u.id = :userId', { userId })
+      .orderBy('cert.issuedAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
+    return { data, total, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+
   async findByIssuerId(
     issuerId: string,
     page = 1,

--- a/backend/src/modules/health/health.controller.ts
+++ b/backend/src/modules/health/health.controller.ts
@@ -34,7 +34,9 @@ export class HealthController {
   })
   async check() {
     try {
-      return await this.health.check([]);
+      return await this.health.check([
+        () => this.stellarHealth.isHealthy(),
+      ]);
     } catch (error) {
       this.logger.error('Health check failed', error);
       throw new HttpException(

--- a/backend/src/modules/webhooks/webhooks.module.ts
+++ b/backend/src/modules/webhooks/webhooks.module.ts
@@ -10,12 +10,21 @@ import { WebhookSubscription } from './entities/webhook-subscription.entity';
 import { WebhookLog } from './entities/webhook-log.entity';
 import { AuthModule } from '../auth/auth.module';
 
+// Retry delays: 1min, 5min, 30min, 2hr, 12hr
+const WEBHOOK_RETRY_DELAYS = [60_000, 300_000, 1_800_000, 7_200_000, 43_200_000];
+
 @Global() // Make it global so it's available everywhere without importing
 @Module({
   imports: [
     TypeOrmModule.forFeature([WebhookSubscription, WebhookLog]),
     BullModule.registerQueue({
       name: 'webhooks',
+      settings: {
+        backoffStrategies: {
+          webhookRetry: (attemptsMade: number) =>
+            WEBHOOK_RETRY_DELAYS[Math.min(attemptsMade, WEBHOOK_RETRY_DELAYS.length - 1)],
+        },
+      },
     }),
     BullBoardModule.forFeature({
       name: 'webhooks',

--- a/backend/src/modules/webhooks/webhooks.service.ts
+++ b/backend/src/modules/webhooks/webhooks.service.ts
@@ -115,8 +115,7 @@ export class WebhooksService {
       {
         attempts: 5,
         backoff: {
-          type: 'exponential',
-          delay: 1000,
+          type: 'webhookRetry',
         },
         removeOnComplete: true,
       },


### PR DESCRIPTION
## Summary

Resolves all 4 issues assigned to LaGodxy.

---

### Closes #339 — Pagination on `GET /certificates/user/:userId`

- Added `findByUserId(userId, page, limit)` to `CertificateRepository` — joins the `users` table on `email = recipientEmail` to resolve certificates by user ID
- Added `getUserCertificates(userId, page, limit)` to `CertificateService`
- Added `GET /certificates/user/:userId?page=1&limit=10` endpoint to `CertificateController`

### Closes #342 — Stellar/Horizon health check on `GET /health`

- The main `GET /health` endpoint was calling `health.check([])` with no indicators
- Now includes `stellarHealth.isHealthy()` so Horizon connectivity is verified on every health poll

### Closes #345 — Request ID correlation across services

- `CorrelationIdMiddleware` was reading `x-request-id` from the incoming header but never generating one if absent
- Now generates a UUID v4 `requestId` when no `x-request-id` header is provided
- The generated ID is echoed back in the `x-request-id` response header and included in all log entries

### Closes #348 — Webhook retry with fixed backoff delays

- Replaced exponential backoff (1 s base) with a custom `webhookRetry` backoff strategy
- Retry delays: **1 min → 5 min → 30 min → 2 hr → 12 hr** (5 attempts total)
- Strategy registered via `settings.backoffStrategies` on the BullMQ webhooks queue

## Files changed

| File | Change |
|------|--------|
| `certificate.repository.ts` | Add `findByUserId` with user-join query |
| `certificate.service.ts` | Add `getUserCertificates` |
| `certificate.controller.ts` | Add `GET /user/:userId` endpoint |
| `health.controller.ts` | Include Stellar indicator in main health check |
| `correlation-id.middleware.ts` | Generate UUID requestId when header absent |
| `webhooks.module.ts` | Register `webhookRetry` backoff strategy |
| `webhooks.service.ts` | Use `webhookRetry` backoff type |