### PR TITLE
feat: Add toast notification for copy feedback in VerifyCertificate

### DIFF
--- a/frontend/src/pages/VerifyCertificate.tsx
+++ b/frontend/src/pages/VerifyCertificate.tsx
@@ -3,6 +3,8 @@ import type { JSX } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Html5QrcodeScanner } from 'html5-qrcode';
 import { certificateApi, VerificationResult } from '../api';
+import { toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 // Debounce hook for search inputs
 const useDebounce = (value: string, delay: number) => {
@@ -463,7 +465,7 @@ export default function VerifyCertificate(): JSX.Element {
                     onClick={() => {
                       const url = `${window.location.origin}/verify?serial=${encodeURIComponent(serial)}`;
                       navigator.clipboard.writeText(url);
-                      // Could add a toast notification here
+                      toast.success('Link copied to clipboard!');
                     }}
                     className="flex items-center gap-2 rounded-lg border border-white/10 bg-slate-800/50 px-3 py-2 text-sm text-white hover:bg-slate-700/50 transition"
                   >


### PR DESCRIPTION
**Closes #266**

#### Summary
This pull request implements a toast notification to provide user feedback when the "Copy Link" button is clicked in the `VerifyCertificate` page. The notification informs users that the verification link has been successfully copied to the clipboard.

#### Changes
- Added `react-toastify` for toast notifications.
- Integrated a success toast message when the "Copy Link" button is clicked.

#### Testing
- Verified that the toast notification appears when the "Copy Link" button is clicked.
- Ensured no build errors and that the feature meets the acceptance criteria.

---

You can now create the pull request on GitHub using this description. Let me know if you need further assistance!