### PR TITLE
fix(security): hash password reset tokens with bcrypt before database storage

### DIFF
--- a/backend/src/modules/users/repositories/user.repository.ts
+++ b/backend/src/modules/users/repositories/user.repository.ts
@@ -5,6 +5,8 @@ import {
   SelectQueryBuilder,
   FindOptionsWhere,
   ILike,
+  Not,
+  IsNull,
 } from 'typeorm';
 import { User, UserRole, UserStatus } from '../entities/user.entity';
 import { IPaginatedResult, IPaginationOptions } from '../interfaces';
@@ -60,8 +62,10 @@ export class UserRepository {
     });
   }
 
-  async findByPasswordResetToken(token: string): Promise<User | null> {
-    return this.repository.findOne({ where: { passwordResetToken: token } });
+  async findUsersWithPasswordResetTokens(): Promise<User[]> {
+    return this.repository.find({
+      where: { passwordResetToken: Not(IsNull()) },
+    });
   }
 
   async findByRefreshToken(refreshToken: string): Promise<User | null> {

--- a/backend/src/modules/users/users.service.spec.ts
+++ b/backend/src/modules/users/users.service.spec.ts
@@ -19,6 +19,11 @@ import { ChangePasswordDto } from './dto/change-password.dto';
 import { EmailQueueService } from '../email/email-queue.service';
 import { CertificateStatsService } from '../certificate/services/stats.service';
 import { AuditService } from '../audit/services/audit.service';
+import { LoggingService } from '../../common/logging/logging.service';
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'mock-uuid'),
+}));
 
 // Mock bcrypt
 jest.mock('bcryptjs', () => ({
@@ -78,7 +83,7 @@ describe('UsersService', () => {
     findByUsername: jest.fn(),
     findByStellarPublicKey: jest.fn(),
     findByEmailVerificationToken: jest.fn(),
-    findByPasswordResetToken: jest.fn(),
+    findUsersWithPasswordResetTokens: jest.fn(),
     findByRefreshToken: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
@@ -121,6 +126,11 @@ describe('UsersService', () => {
     search: jest.fn(),
   };
 
+  const mockLogger = {
+    log: jest.fn(),
+    error: jest.fn(),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -150,6 +160,10 @@ describe('UsersService', () => {
         {
           provide: AuditService,
           useValue: mockAuditService,
+        },
+        {
+          provide: LoggingService,
+          useValue: mockLogger,
         },
       ],
     }).compile();
@@ -534,15 +548,37 @@ describe('UsersService', () => {
     it('should generate reset token for existing user', async () => {
       mockUserRepository.findByEmail.mockResolvedValue(mockUser);
       mockUserRepository.update.mockResolvedValue(mockUser);
+      (bcrypt.hash as jest.Mock).mockImplementationOnce(
+        async (value: string) => `hashed-${value}`,
+      );
 
       const result = await service.forgotPassword({ email: mockUser.email });
 
+      const queuedResetEmail =
+        mockEmailQueueService.queuePasswordReset.mock.calls[0][0];
+      const plainToken = queuedResetEmail.resetLink.split('token=')[1];
+      const storedHash = mockUserRepository.update.mock.calls[0][1]
+        .passwordResetToken as string;
+
       expect(result.message).toContain('If the email exists');
-      expect(mockUserRepository.update).toHaveBeenCalled();
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        mockUser.id,
+        expect.objectContaining({
+          passwordResetToken: expect.any(String),
+          passwordResetExpires: expect.any(Date),
+        }),
+      );
+      expect(storedHash).not.toBe(plainToken);
+      expect(bcrypt.hash).toHaveBeenCalledWith(plainToken, 12);
+      (bcrypt.compare as jest.Mock).mockImplementationOnce(
+        async (value: string, hash: string) => hash === `hashed-${value}`,
+      );
+      await expect(bcrypt.compare(plainToken, storedHash)).resolves.toBe(true);
       expect(emailQueueService.queuePasswordReset).toHaveBeenCalledWith(
         expect.objectContaining({
           to: mockUser.email,
           userName: 'John Doe',
+          resetLink: expect.stringContaining(plainToken),
         }),
       );
     });
@@ -552,13 +588,16 @@ describe('UsersService', () => {
     it('should successfully reset password', async () => {
       const userWithToken = {
         ...mockUser,
-        passwordResetToken: 'valid-token',
+        passwordResetToken: 'hashed-valid-token',
         isPasswordResetTokenValid: jest.fn().mockReturnValue(true),
       };
-      mockUserRepository.findByPasswordResetToken.mockResolvedValue(
+      mockUserRepository.findUsersWithPasswordResetTokens.mockResolvedValue([
         userWithToken,
-      );
+      ]);
       mockUserRepository.update.mockResolvedValue(mockUser);
+      (bcrypt.compare as jest.Mock).mockImplementation(
+        async (value: string, hash: string) => hash === `hashed-${value}`,
+      );
 
       const result = await service.resetPassword({
         token: 'valid-token',
@@ -567,10 +606,32 @@ describe('UsersService', () => {
       });
 
       expect(result.message).toBe('Password reset successfully');
+      expect(
+        mockUserRepository.findUsersWithPasswordResetTokens,
+      ).toHaveBeenCalled();
+      expect(bcrypt.compare).toHaveBeenCalledWith(
+        'valid-token',
+        'hashed-valid-token',
+      );
+      expect(mockUserRepository.update).toHaveBeenCalledWith(mockUser.id, {
+        password: 'hashedPassword123',
+        passwordResetToken: undefined,
+        passwordResetExpires: undefined,
+      });
     });
 
     it('should throw BadRequestException for invalid token', async () => {
-      mockUserRepository.findByPasswordResetToken.mockResolvedValue(null);
+      const userWithToken = {
+        ...mockUser,
+        passwordResetToken: 'hashed-valid-token',
+        isPasswordResetTokenValid: jest.fn().mockReturnValue(true),
+      };
+      mockUserRepository.findUsersWithPasswordResetTokens.mockResolvedValue([
+        userWithToken,
+      ]);
+      (bcrypt.compare as jest.Mock).mockImplementation(
+        async (value: string, hash: string) => hash === `hashed-${value}`,
+      );
 
       await expect(
         service.resetPassword({
@@ -578,7 +639,36 @@ describe('UsersService', () => {
           newPassword: 'NewP@ss456',
           confirmPassword: 'NewP@ss456',
         }),
-      ).rejects.toThrow(BadRequestException);
+      ).rejects.toThrow('Invalid reset token');
+      expect(bcrypt.compare).toHaveBeenCalledWith(
+        'invalid-token',
+        'hashed-valid-token',
+      );
+      expect(mockUserRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException for expired matching token', async () => {
+      const userWithExpiredToken = {
+        ...mockUser,
+        passwordResetToken: 'hashed-expired-token',
+        isPasswordResetTokenValid: jest.fn().mockReturnValue(false),
+      };
+      mockUserRepository.findUsersWithPasswordResetTokens.mockResolvedValue([
+        userWithExpiredToken,
+      ]);
+      (bcrypt.compare as jest.Mock).mockImplementation(
+        async (value: string, hash: string) => hash === `hashed-${value}`,
+      );
+
+      await expect(
+        service.resetPassword({
+          token: 'expired-token',
+          newPassword: 'NewP@ss456',
+          confirmPassword: 'NewP@ss456',
+        }),
+      ).rejects.toThrow('Reset token has expired');
+      expect(userWithExpiredToken.isPasswordResetTokenValid).toHaveBeenCalled();
+      expect(mockUserRepository.update).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -360,8 +360,13 @@ export class UsersService {
       passwordResetExpires.getHours() + this.PASSWORD_RESET_EXPIRY_HOURS,
     );
 
-    await this.userRepository.update(user.id, {
+    const hashedPasswordResetToken = await bcrypt.hash(
       passwordResetToken,
+      this.SALT_ROUNDS,
+    );
+
+    await this.userRepository.update(user.id, {
+      passwordResetToken: hashedPasswordResetToken,
       passwordResetExpires,
     });
 
@@ -383,7 +388,24 @@ export class UsersService {
       throw new BadRequestException('Passwords do not match');
     }
 
-    const user = await this.userRepository.findByPasswordResetToken(token);
+    const usersWithResetTokens =
+      await this.userRepository.findUsersWithPasswordResetTokens();
+    let user: User | null = null;
+
+    for (const candidate of usersWithResetTokens) {
+      if (!candidate.passwordResetToken) {
+        continue;
+      }
+
+      const tokenMatches = await bcrypt.compare(
+        token,
+        candidate.passwordResetToken,
+      );
+      if (tokenMatches) {
+        user = candidate;
+        break;
+      }
+    }
 
     if (!user) {
       throw new BadRequestException('Invalid reset token');


### PR DESCRIPTION

---

## Summary
This PR fixes a security vulnerability in `users.service.ts` where password reset tokens were stored in plain text. A compromised database would expose all active reset tokens as immediately usable. Reset tokens are now hashed with bcrypt before storage, consistent with how passwords are handled.

Closes #333

---

## #333 — Password Reset Token Stored in Plain Text

### What changed
- Updated `users.service.ts` to hash the generated reset token with **bcrypt** before writing it to the database
- The raw token is returned to the user (for inclusion in the reset link) but only the hash is persisted
- On reset, the submitted token is compared against the stored hash using `bcrypt.compare` — matching the existing password verification pattern
- Existing plain-text tokens in the database are invalidated on deploy; users with pending resets will need to request a new one

### How to verify
- Trigger a password reset and assert the value stored in the database is a bcrypt hash, not the raw token
- Submit the correct raw token via the reset endpoint and assert it is accepted
- Submit an incorrect token and assert it is rejected with `401`
- Assert the flow is consistent with how password hashing is handled elsewhere in the service

---

## Checklist
- [ ] Reset token hashed with bcrypt before insert
- [ ] Raw token returned to user for reset link only
- [ ] Token verification uses `bcrypt.compare`
- [ ] No plain-text tokens written anywhere in the reset flow
- [ ] Existing plain-text tokens invalidated on deploy
- [ ] Behaviour consistent with password hashing pattern
- [ ] Closes #333