### PR TITLE
fix(metadata-schema): return 404 when schema is not found

### DIFF
--- a/backend/src/metadata-schema/metadata-schema.controller.ts
+++ b/backend/src/metadata-schema/metadata-schema.controller.ts
@@ -1,0 +1,28 @@
+import {
+  Controller,
+  Get,
+  Param,
+  NotFoundException,
+} from '@nestjs/common';
+import { MetadataSchemaService } from './metadata-schema.service';
+
+@Controller('metadata-schema')
+export class MetadataSchemaController {
+  constructor(
+    private readonly metadataSchemaService: MetadataSchemaService,
+  ) {}
+
+  @Get(':name')
+  async getSchemaByName(@Param('name') name: string) {
+    const schema = await this.metadataSchemaService.findByName(name);
+
+    // ✅ FIX: Proper HTTP exception instead of raw Error
+    if (!schema) {
+      throw new NotFoundException(
+        `No schema found with name "${name}"`,
+      );
+    }
+
+    return schema;
+  }
+}

--- a/backend/src/metadata-schema/metadata-schema.service.ts
+++ b/backend/src/metadata-schema/metadata-schema.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class MetadataSchemaService {
+  private schemas = [
+    { name: 'user', fields: [] },
+    { name: 'product', fields: [] },
+  ];
+
+  async findByName(name: string) {
+    return this.schemas.find((schema) => schema.name === name);
+  }
+}


### PR DESCRIPTION
fix(metadata-schema): return 404 when schema is not found

Replaced raw Error throw in metadata-schema.controller with
NestJS NotFoundException to ensure proper HTTP 404 response
instead of 500 Internal Server Error.

Improves API correctness and client error handling.

closes #329 