### PR TITLE
Track pending request rejection reasons

### DIFF
--- a/backend/src/modules/multisig/multisig.service.ts
+++ b/backend/src/modules/multisig/multisig.service.ts
@@ -41,6 +41,7 @@ export interface PendingRequest {
   proposer: string;
   approvals: string[];
   rejections: string[];
+  rejection_reason?: string;
   created_at: number;
   expires_at: number;
   status: RequestStatus;
@@ -817,6 +818,9 @@ export class MultisigService {
       proposer: r['proposer'] as string,
       approvals: (r['approvals'] as string[]) ?? [],
       rejections: (r['rejections'] as string[]) ?? [],
+      rejection_reason: r['rejection_reason'] != null
+        ? String(r['rejection_reason'])
+        : undefined,
       created_at: Number(r['created_at']),
       expires_at: Number(r['expires_at']),
       status: Number(r['status']) as RequestStatus,

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -338,6 +338,7 @@ impl CertificateContract {
             proposer: issuer.clone(),
             approvals: Vec::new(&env),
             rejections: Vec::new(&env),
+            rejection_reason: None,
             created_at: env.ledger().timestamp(),
             expires_at: env.ledger().timestamp() + (expiration_days as u64 * 24 * 60 * 60),
             status: RequestStatus::Pending,
@@ -425,7 +426,7 @@ impl CertificateContract {
         env: Env,
         request_id: String,
         rejector: Address,
-        _reason: Option<String>,
+        reason: Option<String>,
     ) -> SignatureResult {
         rejector.require_auth();
         let mut request: PendingRequest = env
@@ -450,6 +451,9 @@ impl CertificateContract {
 
         if !request.rejections.contains(&rejector) {
             request.rejections.push_back(rejector);
+            if reason.is_some() {
+                request.rejection_reason = reason;
+            }
         }
 
         let remaining_eligible_approvers = config

--- a/stellar-contracts/src/multisig.rs
+++ b/stellar-contracts/src/multisig.rs
@@ -143,6 +143,7 @@ impl MultisigCertificateContract {
             proposer: issuer.clone(),
             approvals: Vec::new(&env),
             rejections: Vec::new(&env),
+            rejection_reason: None,
             created_at: env.ledger().timestamp(),
             expires_at: env.ledger().timestamp() + (expiration_days as u64 * 24 * 60 * 60), // Convert days to seconds
             status: RequestStatus::Pending,
@@ -242,7 +243,7 @@ impl MultisigCertificateContract {
         env: Env,
         request_id: String,
         rejector: Address,
-        _reason: Option<String>,
+        reason: Option<String>,
     ) -> SignatureResult {
         rejector.require_auth();
 
@@ -288,6 +289,9 @@ impl MultisigCertificateContract {
 
         // Add rejection
         request.rejections.push_back(rejector);
+        if reason.is_some() {
+            request.rejection_reason = reason;
+        }
 
         let remaining_eligible_approvers = config
             .signers

--- a/stellar-contracts/src/multisig_test.rs
+++ b/stellar-contracts/src/multisig_test.rs
@@ -124,12 +124,15 @@ fn test_reject_request() {
     client.propose_certificate(&request_id, &issuer, &recipient, &metadata, &7);
 
     // Reject by one signer
-    let result = client.reject_request(&request_id, &signer1, &None);
+    let rejection_reason = String::from_str(&env, "Insufficient supporting documentation");
+    let result = client.reject_request(&request_id, &signer1, &Some(rejection_reason.clone()));
     assert!(result.success);
     assert_eq!(
         result.final_status,
         OptionalRequestStatus::Some(RequestStatus::Pending)
     );
+    let request = client.get_pending_request(&request_id);
+    assert_eq!(request.rejection_reason, Some(rejection_reason));
 
     // Approve by another signer
     let result = client.approve_request(&request_id, &signer2);

--- a/stellar-contracts/src/openApi.rs
+++ b/stellar-contracts/src/openApi.rs
@@ -491,6 +491,7 @@ impl MultisigCertificateContract {
             proposer: issuer.clone(),
             approvals: Vec::new(&env),
             rejections: Vec::new(&env),
+            rejection_reason: None,
             created_at: env.ledger().timestamp(),
             expires_at: env.ledger().timestamp() + (expiration_days as u64 * 24 * 60 * 60), // Convert days to seconds
             status: RequestStatus::Pending,
@@ -590,7 +591,7 @@ impl MultisigCertificateContract {
         env: Env,
         request_id: String,
         rejector: Address,
-        _reason: Option<String>,
+        reason: Option<String>,
     ) -> SignatureResult {
         rejector.require_auth();
 
@@ -636,6 +637,9 @@ impl MultisigCertificateContract {
 
         // Add rejection
         request.rejections.push_back(rejector);
+        if reason.is_some() {
+            request.rejection_reason = reason;
+        }
 
         let remaining_eligible_approvers = config
             .signers

--- a/stellar-contracts/src/types.rs
+++ b/stellar-contracts/src/types.rs
@@ -86,6 +86,7 @@ pub struct PendingRequest {
     pub proposer: Address,
     pub approvals: Vec<Address>,
     pub rejections: Vec<Address>,
+    pub rejection_reason: Option<String>,
     pub created_at: u64,
     pub expires_at: u64,
     pub status: RequestStatus,


### PR DESCRIPTION
The reject_request() accepted a rejection reason but discarded it, so I added storage and parsing for that reason on PendingRequest for auditability.

closes #405