### PR TITLE
fix(contracts): add remove_issuer and execute RemoveIssuer via admin multisig

### DIFF
--- a/stellar-contracts/src/admin_multisig.rs
+++ b/stellar-contracts/src/admin_multisig.rs
@@ -1,5 +1,6 @@
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, String, Vec,
+    contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, IntoVal, String,
+    Vec,
 };
 
 #[contracttype]
@@ -225,6 +226,24 @@ impl AdminMultisigContract {
         Self::approve_action(env, proposal_id, approver)
     }
 
+    pub fn set_certificate_contract(env: Env, signer: Address, certificate_contract: Address) {
+        signer.require_auth();
+
+        let config = Self::get_config(env.clone());
+        Self::require_signer(&config.signers, &signer);
+
+        env.storage()
+            .instance()
+            .set(&AdminMultisigDataKey::CertificateContractId, &certificate_contract);
+    }
+
+    pub fn get_certificate_contract(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&AdminMultisigDataKey::CertificateContractId)
+            .expect("Certificate contract not configured")
+    }
+
     fn execute_action(env: Env, proposal_id: String) -> AdminProposalStatus {
         let proposal_key = AdminMultisigDataKey::AdminProposal(proposal_id.clone());
         let mut proposal: AdminProposal = env
@@ -246,6 +265,18 @@ impl AdminMultisigContract {
                 env.storage()
                     .instance()
                     .set(&AdminMultisigDataKey::RemovedIssuer(issuer.clone()), &true);
+
+                let certificate_contract: Address = env
+                    .storage()
+                    .instance()
+                    .get(&AdminMultisigDataKey::CertificateContractId)
+                    .expect("Certificate contract not configured");
+
+                let _: () = env.invoke_contract(
+                    &certificate_contract,
+                    &soroban_sdk::Symbol::new(&env, "remove_issuer"),
+                    soroban_sdk::vec![&env, issuer.clone().into_val(&env)],
+                );
             }
             AdminAction::UpdateConfig(threshold, signers, proposal_window) => {
                 Self::validate_config(signers, *threshold, *proposal_window);

--- a/stellar-contracts/src/admin_multisig_test.rs
+++ b/stellar-contracts/src/admin_multisig_test.rs
@@ -47,12 +47,15 @@ fn test_admin_multisig_flow() {
 #[test]
 fn test_remove_issuer_action_executes_after_threshold() {
     let env = Env::default();
-    let contract_id = env.register_contract(None, AdminMultisigContract);
-    let client = AdminMultisigContractClient::new(&env, &contract_id);
+    let admin_multisig_contract_id = env.register_contract(None, AdminMultisigContract);
+    let client = AdminMultisigContractClient::new(&env, &admin_multisig_contract_id);
+    let certificate_contract_id = env.register_contract(None, CertificateContract);
+    let certificate_client = CertificateContractClient::new(&env, &certificate_contract_id);
 
     let admin1 = Address::generate(&env);
     let admin2 = Address::generate(&env);
     let issuer = Address::generate(&env);
+    let owner = Address::generate(&env);
 
     let mut signers = Vec::new(&env);
     signers.push_back(admin1.clone());
@@ -60,7 +63,11 @@ fn test_remove_issuer_action_executes_after_threshold() {
 
     env.mock_all_auths();
 
+    certificate_client.initialize(&admin_multisig_contract_id);
+    certificate_client.add_issuer(&issuer);
+
     client.init_admin_multisig(&2, &signers, &5);
+    client.set_certificate_contract(&admin1, &certificate_contract_id);
 
     let proposal_id = String::from_str(&env, "remove-issuer-1");
     let action = AdminAction::RemoveIssuer(issuer.clone());
@@ -74,4 +81,13 @@ fn test_remove_issuer_action_executes_after_threshold() {
     let status = client.approve_action(&proposal_id, &admin2);
     assert_eq!(status, AdminProposalStatus::Executed);
     assert!(client.is_issuer_removed(&issuer));
+
+    let issue_result = certificate_client.try_issue_certificate(
+        &String::from_str(&env, "issuer-removed-cert"),
+        &issuer,
+        &owner,
+        &String::from_str(&env, "ipfs://meta"),
+        &None,
+    );
+    assert!(issue_result.is_err());
 }

--- a/stellar-contracts/src/issuer_management_test.rs
+++ b/stellar-contracts/src/issuer_management_test.rs
@@ -1,0 +1,49 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+#[test]
+fn test_remove_issuer_clears_issuer_storage() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, CertificateContract);
+    let client = CertificateContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let owner = Address::generate(&env);
+
+    let id = String::from_str(&env, "cert-remove-issuer");
+    let metadata_uri = String::from_str(&env, "ipfs://meta");
+
+    client.initialize(&admin);
+    client.add_issuer(&issuer);
+
+    client.remove_issuer(&issuer);
+
+    let issue_result = client.try_issue_certificate(&id, &issuer, &owner, &metadata_uri, &None);
+    assert!(issue_result.is_err());
+}
+
+#[test]
+fn test_remove_issuer_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, CertificateContract);
+    let client = CertificateContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    // Removing a non-existent issuer should be a no-op.
+    client.remove_issuer(&issuer);
+
+    client.add_issuer(&issuer);
+    client.remove_issuer(&issuer);
+    client.remove_issuer(&issuer);
+}

--- a/stellar-contracts/src/lib.rs
+++ b/stellar-contracts/src/lib.rs
@@ -20,6 +20,8 @@ pub use admin_multisig::*;
 mod admin_multisig_test;
 #[cfg(test)]
 mod multisig_test;
+#[cfg(test)]
+mod issuer_management_test;
 
 #[contract]
 pub struct CertificateContract;
@@ -45,6 +47,17 @@ impl CertificateContract {
         env.storage()
             .instance()
             .set(&DataKey::Issuer(issuer), &true);
+    }
+
+    /// Remove an authorized issuer (only admin can call)
+    pub fn remove_issuer(env: Env, issuer: Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Contract not initialized");
+        admin.require_auth();
+        env.storage().instance().remove(&DataKey::Issuer(issuer));
     }
 
     /// Issue a new certificate


### PR DESCRIPTION
## What this PR does
This PR closes the gap in issuer lifecycle management by adding a real issuer removal flow in the certificate contract and wiring the admin multisig action to execute it.

### Changes made
- Added `remove_issuer(env, issuer)` to `CertificateContract`.
  - Requires admin auth.
  - Removes `DataKey::Issuer(address)` from storage.
- Updated `AdminMultisigContract` so `AdminAction::RemoveIssuer` does more than set an internal flag:
  - It now invokes `CertificateContract::remove_issuer` on execution.
- Added certificate contract wiring helpers in admin multisig:
  - `set_certificate_contract`
  - `get_certificate_contract`
- Added/updated tests to cover:
  - Direct issuer removal from `CertificateContract`.
  - Removal via approved admin multisig proposal.

## Why this change is needed
Issue #398 identified two problems:
1. `CertificateContract` had `add_issuer()` but no corresponding remove function.
2. `AdminMultisigContract` `RemoveIssuer` only set local state and did not update issuer authorization in `CertificateContract`.

This PR addresses both so issuer removal is actually enforced by the certificate contract.

## How I verified
- Ran contract tests:
  - `cd stellar-contracts`
  - `cargo test`
- Result: **17 passed, 0 failed**

Fixes #398
