### PR TITLE
fix(frontend): remove runtime dummy data toggle for production builds

### DIFF
--- a/frontend/src/api/endpoints.test.ts
+++ b/frontend/src/api/endpoints.test.ts
@@ -1,0 +1,7 @@
+import * as endpoints from './endpoints';
+
+describe('frontend api endpoints', () => {
+  it('does not expose a runtime toggleDummyData helper', () => {
+    expect((endpoints as Record<string, unknown>).toggleDummyData).toBeUndefined();
+  });
+});

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -39,14 +39,12 @@ interface AuditLogQueryParams {
   limit?: number;
 }
 
-// Configuration flag - can be enabled via Vite env `VITE_USE_DUMMY_DATA` ("true"/"false").
-const VITE_USE_DUMMY = (
-  import.meta as unknown as { env: Record<string, string> }
-).env?.VITE_USE_DUMMY_DATA;
-let USE_DUMMY_DATA = VITE_USE_DUMMY ? VITE_USE_DUMMY === "true" : false;
-const API_URL_BASE =
-  (import.meta as unknown as { env: Record<string, string> }).env
-    ?.VITE_API_URL || "http://localhost:3000/api/v1";
+// Configuration flag - can be enabled via Vite env `VITE_USE_DUMMY_DATA` ("true"/"false") in development only.
+const viteEnv = import.meta as unknown as { env: Record<string, string> };
+const USE_DUMMY_DATA =
+  viteEnv.env?.VITE_USE_DUMMY_DATA === "true" &&
+  viteEnv.env?.MODE !== "production";
+const API_URL_BASE = viteEnv.env?.VITE_API_URL || "http://localhost:3000/api/v1";
 export const API_URL = API_URL_BASE;
 
 // Helper function to simulate API delay
@@ -1150,10 +1148,6 @@ export const adminAnalyticsApi = {
     if (params?.endDate) searchParams.set("endDate", params.endDate);
     return apiClient(`/admin/analytics?${searchParams.toString()}`);
   },
-};
-
-export const toggleDummyData = (useDummy: boolean) => {
-  USE_DUMMY_DATA = useDummy;
 };
 
 export const issuerProfileApi = {


### PR DESCRIPTION
Summary:
- Removed the runtime `toggleDummyData()` helper from `frontend/src/api/endpoints.ts`.
- Gated dummy data behind `VITE_USE_DUMMY_DATA === "true"` only when not in production.
- Added a focused endpoint test to ensure the runtime toggle is no longer exposed.

What changed:
- `frontend/src/api/endpoints.ts`
- `frontend/src/api/endpoints.test.ts`

Why:
- `USE_DUMMY_DATA` should not be mutable at runtime in production builds.
- This keeps development-only dummy data behavior behind build-time configuration.

Testing performed:
- `npx vitest run src/api/endpoints.test.ts`
- Verified the modified file compiles with frontend-compatible TypeScript options.

Risks considered:
- Change is scoped to frontend API configuration and does not affect unrelated modules.

Closes #319