### PR TITLE
fix: prevent /certificates/export routing to :id

### DIFF
--- a/backend/src/modules/certificate/certificate.controller.ts
+++ b/backend/src/modules/certificate/certificate.controller.ts
@@ -206,6 +206,17 @@ export class CertificateController {
     return this.certificateService.getUserCertificates(userId, +page, +limit);
   }
 
+  @Get('export')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ISSUER, UserRole.ADMIN)
+  @ApiOperation({ summary: 'Export certificates' })
+  async exportCertificates(
+    @Query('issuerId') issuerId?: string,
+    @Query('status') status?: string,
+  ) {
+    return this.certificateService.exportCertificates(issuerId, status);
+  }
+
   // ─── Single Certificate ───────────────────────────────────────────────────────
 
   @Get(':id/qr')
@@ -355,17 +366,6 @@ export class CertificateController {
       issuerId,
       userRole,
     );
-  }
-
-  @Get('export')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles(UserRole.ISSUER, UserRole.ADMIN)
-  @ApiOperation({ summary: 'Export certificates' })
-  async exportCertificates(
-    @Query('issuerId') issuerId?: string,
-    @Query('status') status?: string,
-  ) {
-    return this.certificateService.exportCertificates(issuerId, status);
   }
 
   @Post('export')


### PR DESCRIPTION
## Summary
- Moves `GET /certificates/export` above the dynamic `GET /certificates/:id` route so it no longer matches `id=export` and throws a UUID parse error.

## Validation
- `backend/npm run typecheck`: fails due to pre-existing TypeScript errors (missing modules, type mismatches, and DTO ordering) unrelated to this change.
- `backend/npm test`: fails due to watchman permission issues.
- `backend/node ../node_modules/jest/bin/jest.js --watchman=false`: runs but multiple suites fail pre-existing (e.g. jest ESM parsing error from `uuid/dist-node`, plus various DI/mocking failures).

Closes #469
Closes #470
Closes #471
Closes #472
