### PR TITLE
Add rate limiting to /auth/refresh endpoint

### DIFF
--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -79,6 +79,7 @@ export class AuthController {
   }
 
   @Post('refresh')
+  @RateLimit({ limit: 10, windowMs: 60_000, keyBy: 'ip' })
   @Public()
   @HttpCode(HttpStatus.OK)
   async refresh(@Body() refreshDto: RefreshDto): Promise<AuthResponseDto> {


### PR DESCRIPTION
The `/auth/refresh` endpoint had no rate limit, meaning a stolen refresh token could be used in a tight loop to generate new access tokens indefinitely.

Adds the same IP-based `@RateLimit` decorator already applied to `/auth/login` and `/auth/register`.

Closes #489