### PR TITLE
Disable TypeORM synchronize and configure migrations path

### DIFF
--- a/backend/src/config/typeorm.config.ts
+++ b/backend/src/config/typeorm.config.ts
@@ -8,7 +8,9 @@ export const typeOrmConfig: TypeOrmModuleOptions = {
   password: process.env.DB_PASSWORD || 'stellarwave_password',
   database: process.env.DB_NAME || 'stellarwave',
   entities: [__dirname + '/../**/*.entity{.ts,.js}'],
-  synchronize: process.env.NODE_ENV !== 'production',
+  synchronize: false,
   logging: process.env.NODE_ENV !== 'production',
   autoLoadEntities: true,
+  migrations: [__dirname + '/../migrations/*{.ts,.js}'],
+  migrationsRun: false,
 };


### PR DESCRIPTION
Using `synchronize: true` in production automatically alters the database schema on startup, which can silently drop columns or cause data loss when entity definitions change.

- Sets `synchronize: false` unconditionally
- Adds a `migrations` path so the TypeORM CLI can generate and run migration files safely

Closes #492