### PR TITLE
Add RECIPIENT and VERIFIER role counts to getUserStats

### DIFF
--- a/backend/src/modules/users/entities/user.entity.ts
+++ b/backend/src/modules/users/entities/user.entity.ts
@@ -11,6 +11,8 @@ export enum UserRole {
   USER = 'user',
   ISSUER = 'issuer',
   ADMIN = 'admin',
+  RECIPIENT = 'recipient',
+  VERIFIER = 'verifier',
 }
 
 export enum UserStatus {

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -303,13 +303,15 @@ export class UsersService {
     certificateIssuanceCounts: Record<string, number>;
   }> {
     // This method is kept in UsersService as it aggregates data from multiple services
-    const [total, active, userCount, issuerCount, adminCount] =
+    const [total, active, userCount, issuerCount, adminCount, recipientCount, verifierCount] =
       await Promise.all([
         this.userRepository.countTotal(),
         this.userRepository.countActive(),
         this.userRepository.countByRole(UserRole.USER),
         this.userRepository.countByRole(UserRole.ISSUER),
         this.userRepository.countByRole(UserRole.ADMIN),
+        this.userRepository.countByRole(UserRole.RECIPIENT),
+        this.userRepository.countByRole(UserRole.VERIFIER),
       ]);
 
     const [activeStatus, inactiveStatus, suspendedStatus, pendingStatus] =
@@ -330,6 +332,8 @@ export class UsersService {
         [UserRole.USER]: userCount,
         [UserRole.ISSUER]: issuerCount,
         [UserRole.ADMIN]: adminCount,
+        [UserRole.RECIPIENT]: recipientCount,
+        [UserRole.VERIFIER]: verifierCount,
       },
       byStatus: {
         [UserStatus.ACTIVE]: activeStatus,


### PR DESCRIPTION
The `UserRole` enum was missing `RECIPIENT` and `VERIFIER` values. As a result, `getUserStats()` only counted `USER`, `ISSUER`, and `ADMIN` roles, leaving the admin analytics dashboard with incomplete totals.

- Adds `RECIPIENT` and `VERIFIER` to the `UserRole` enum
- Includes both roles in the `byRole` map returned by `getUserStats()`

Closes #491