### PR TITLE
Add GET /certificates/:id/pdf endpoint for certificate download

### DIFF
--- a/backend/src/modules/certificate/certificate.controller.ts
+++ b/backend/src/modules/certificate/certificate.controller.ts
@@ -15,8 +15,9 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
-import type { Request } from 'express';
+import type { Request, Response } from 'express';
 import { CertificateService } from './certificate.service';
+import { CertificatePdfService } from './services/pdf.service';
 import {
   ApiTags,
   ApiOperation,
@@ -57,6 +58,7 @@ export class CertificateController {
   constructor(
     private readonly certificateService: CertificateService,
     private readonly statsService: CertificateStatsService,
+    private readonly pdfService: CertificatePdfService,
   ) {}
 
   // ─── List / Search ──────────────────────────────────────────────────────────
@@ -207,6 +209,22 @@ export class CertificateController {
   }
 
   // ─── Single Certificate ───────────────────────────────────────────────────────
+
+  @Get(':id/pdf')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Download certificate as PDF' })
+  @ApiParam({ name: 'id', description: 'Certificate UUID' })
+  @ApiResponse({ status: 200, description: 'PDF file stream' })
+  async getCertificatePdf(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    const certificate = await this.certificateService.findOne(id);
+    const buffer = await this.pdfService.generate(certificate);
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `attachment; filename="${certificate.certificateId}.pdf"`);
+    res.end(buffer);
+  }
 
   @Get(':id/qr')
   @ApiOperation({ summary: 'Get QR code URL for a certificate' })

--- a/backend/src/modules/certificate/certificate.module.ts
+++ b/backend/src/modules/certificate/certificate.module.ts
@@ -9,6 +9,7 @@ import { Verification } from './entities/verification.entity';
 import { CertificateService } from './certificate.service';
 import { CertificateStatsService } from './services/stats.service';
 import { DuplicateDetectionService } from './services/duplicate-detection.service';
+import { CertificatePdfService } from './services/pdf.service';
 
 import { CertificateController } from './certificate.controller';
 import { DuplicateDetectionController } from './controllers/duplicate-detection.controller';
@@ -47,6 +48,7 @@ import { EmailModule } from '../email/email.module';
     CertificateService,
     CertificateStatsService,
     DuplicateDetectionService,
+    CertificatePdfService,
   ],
   exports: [CertificateService, CertificateStatsService],
 })

--- a/backend/src/modules/certificate/services/pdf.service.ts
+++ b/backend/src/modules/certificate/services/pdf.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import PDFDocument from 'pdfkit';
+import { Certificate } from '../entities/certificate.entity';
+
+@Injectable()
+export class CertificatePdfService {
+  generate(certificate: Certificate): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const doc = new PDFDocument({ size: 'A4', margin: 60 });
+      const chunks: Buffer[] = [];
+
+      doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+      doc.on('end', () => resolve(Buffer.concat(chunks)));
+      doc.on('error', reject);
+
+      doc
+        .fontSize(26)
+        .font('Helvetica-Bold')
+        .text('Certificate of Achievement', { align: 'center' });
+      doc.moveDown();
+      doc.fontSize(13).font('Helvetica').text('This certifies that', { align: 'center' });
+      doc.moveDown(0.5);
+      doc.fontSize(20).font('Helvetica-Bold').text(certificate.recipientName, { align: 'center' });
+      doc.moveDown();
+      doc.fontSize(13).font('Helvetica').text(certificate.title, { align: 'center' });
+
+      if (certificate.courseName) {
+        doc.fontSize(12).text(`Course: ${certificate.courseName}`, { align: 'center' });
+      }
+
+      doc.moveDown();
+      doc.fontSize(11).text(`Certificate ID: ${certificate.certificateId}`, { align: 'center' });
+      doc.fontSize(11).text(`Issued by: ${certificate.issuerName ?? 'Unknown'}`, { align: 'center' });
+      doc.fontSize(11).text(`Issued on: ${new Date(certificate.issuedAt).toLocaleDateString()}`, { align: 'center' });
+
+      if (certificate.expiresAt) {
+        doc.fontSize(11).text(`Expires: ${new Date(certificate.expiresAt).toLocaleDateString()}`, { align: 'center' });
+      }
+
+      doc.end();
+    });
+  }
+}


### PR DESCRIPTION
The frontend `CertificateWallet` calls `GET /certificates/:id/pdf` but the endpoint did not exist, causing `getCertificatePdfUrl` to always return null and users unable to download their certificates.

- Adds a `CertificatePdfService` that uses the existing `pdfkit` dependency to generate a certificate PDF on-the-fly
- Adds a `GET /certificates/:id/pdf` route to `CertificateController` that streams the generated PDF back as `application/pdf`
- Registers `CertificatePdfService` in `CertificateModule`

Closes #487