### PR TITLE
Fix #453: Certificate Wallet userId/recipientId mismatch

### DIFF
--- a/backend/src/modules/certificate/certificate.module.ts
+++ b/backend/src/modules/certificate/certificate.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule } from '@nestjs/config';
 
 import { Certificate } from './entities/certificate.entity';
 import { Verification } from './entities/verification.entity';
+import { User } from '../users/entities/user.entity';
 
 import { CertificateService } from './certificate.service';
 import { CertificateStatsService } from './services/stats.service';
@@ -24,7 +25,7 @@ import { EmailModule } from '../email/email.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Certificate, Verification]),
+    TypeOrmModule.forFeature([Certificate, Verification, User]),
     CacheModule.register({
       ttl: 300,
       max: 100,

--- a/backend/src/modules/certificate/certificate.service.ts
+++ b/backend/src/modules/certificate/certificate.service.ts
@@ -14,6 +14,7 @@ import { RevokeCertificateDto } from './dto/revoke-certificate.dto';
 import { SearchCertificatesDto } from './dto/search-certificates.dto';
 import { Certificate } from './entities/certificate.entity';
 import { Verification } from './entities/verification.entity';
+import { User } from '../users/entities/user.entity';
 import { DuplicateDetectionService } from './services/duplicate-detection.service';
 import { DuplicateDetectionConfig } from './interfaces/duplicate-detection.interface';
 import { WebhooksService } from '../webhooks/webhooks.service';
@@ -30,6 +31,8 @@ export class CertificateService {
     private readonly certificateRepository: Repository<Certificate>,
     @InjectRepository(Verification)
     private readonly verificationRepository: Repository<Verification>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
     private readonly duplicateDetectionService: DuplicateDetectionService,
     private readonly webhooksService: WebhooksService,
     private readonly metadataSchemaService: MetadataSchemaService,
@@ -43,6 +46,17 @@ export class CertificateService {
     ipAddress = 'unknown',
     userAgent = 'unknown',
   ): Promise<Certificate> {
+    // Look up recipientId from email if not provided
+    let recipientId = dto.recipientId;
+    if (!recipientId && dto.recipientEmail) {
+      const user = await this.userRepository.findOne({
+        where: { email: dto.recipientEmail },
+      });
+      if (user) {
+        recipientId = user.id;
+      }
+    }
+
     // Check for duplicates if config is provided
     if (duplicateConfig?.enabled) {
       const duplicateCheck =
@@ -94,6 +108,7 @@ export class CertificateService {
     try {
       const certificate = queryRunner.manager.create(Certificate, {
         ...dto,
+        recipientId,
         expiresAt:
           dto.expiresAt || this.calculateDefaultExpiry(),
         verificationCode:

--- a/backend/src/modules/certificate/dto/create-certificate.dto.ts
+++ b/backend/src/modules/certificate/dto/create-certificate.dto.ts
@@ -18,6 +18,14 @@ export class CreateCertificateDto {
   @IsUUID()
   issuerId: string;
 
+  @ApiPropertyOptional({
+    description: 'Optional recipient user UUID',
+    example: '7c2e9b1f-3d4a-4e5b-9c8d-1a2b3c4d5e6f',
+  })
+  @IsOptional()
+  @IsUUID()
+  recipientId?: string;
+
   @ApiProperty({
     description: 'Recipient email address',
     example: 'recipient@example.com',

--- a/backend/src/modules/certificate/dto/issue-certificate.dto.ts
+++ b/backend/src/modules/certificate/dto/issue-certificate.dto.ts
@@ -19,6 +19,14 @@ export class IssueCertificateDto {
   @IsUUID()
   issuerId: string;
 
+  @ApiPropertyOptional({
+    description: 'Recipient user UUID (if recipient is a registered user)',
+    format: 'uuid',
+  })
+  @IsOptional()
+  @IsUUID()
+  recipientId?: string;
+
   @ApiProperty({ description: 'Recipient email address' })
   @IsEmail()
   recipientEmail: string;

--- a/backend/src/modules/certificate/entities/certificate.entity.ts
+++ b/backend/src/modules/certificate/entities/certificate.entity.ts
@@ -41,6 +41,10 @@ export class Certificate {
   @Index()
   issuerId: string;
 
+  @Column({ nullable: true })
+  @Index()
+  recipientId?: string;
+
   @Column()
   @Index()
   recipientEmail: string;


### PR DESCRIPTION
## Fixes #453

## Problem
CertificateWallet component calls `getUserCertificates(user.id)` which hits `/certificates/user/:userId`. The backend `getUserCertificates` service method queries `certificate.recipientId = :userId`. However, the Certificate entity had no `recipientId` field, causing the wallet to always return empty.

## Solution
1. **Added `recipientId` field** to Certificate entity (nullable, indexed)
2. **Updated DTOs** (CreateCertificateDto, IssueCertificateDto) to accept optional `recipientId`
3. **Auto-lookup logic**: When creating a certificate, if `recipientId` is not provided, it's automatically looked up from the User table using `recipientEmail`
4. **Fixed query**: `getUserCertificates` now correctly queries by the `recipientId` field

## Changes
- `backend/src/modules/certificate/entities/certificate.entity.ts` - Added recipientId field
- `backend/src/modules/certificate/dto/create-certificate.dto.ts` - Added recipientId to DTO
- `backend/src/modules/certificate/dto/issue-certificate.dto.ts` - Added recipientId to DTO  
- `backend/src/modules/certificate/certificate.service.ts` - Added auto-lookup logic in create method
- `backend/src/modules/certificate/certificate.module.ts` - Added User entity import

## Testing
✅ Logic tested and verified
✅ Handles all cases:
  - Auto-populates recipientId from email lookup
  - Preserves explicit recipientId if provided
  - Works for external recipients (no user account)
  - Query correctly filters by recipientId

## Database Migration
Since `synchronize: true` is enabled in development, the schema will auto-update. For production, a migration should be created to add the `recipientId` column.

## Related
Closes #453