### PR TITLE
fix(auth,notifications): separate JWT secrets and add paginated notifications endpoint

### DIFF
--- a/backend/src/common/common.module.ts
+++ b/backend/src/common/common.module.ts
@@ -37,12 +37,12 @@ import { Issuer } from '../modules/issuers/entities/issuer.entity';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        const secret = configService.get<string>('JWT_SECRET');
-        const expiresIn = (configService.get<string>('JWT_EXPIRES_IN') ||
-          '24h') as any;
+        const secret = configService.get<string>('JWT_ACCESS_SECRET');
+        const expiresIn = (configService.get<string>('JWT_ACCESS_EXPIRES_IN') ||
+          '15m') as any;
 
         if (!secret) {
-          throw new Error('JWT_SECRET must be configured');
+          throw new Error('JWT_ACCESS_SECRET must be configured');
         }
 
         return {

--- a/backend/src/common/guards/jwt-auth.guard.ts
+++ b/backend/src/common/guards/jwt-auth.guard.ts
@@ -46,7 +46,7 @@ export class JwtAuthGuard implements CanActivate {
     }
 
     try {
-      const secret = this.configService.get<string>('JWT_SECRET');
+      const secret = this.configService.get<string>('JWT_ACCESS_SECRET');
 
       if (!secret) {
         throw new AuthException(

--- a/backend/src/config/environment.config.ts
+++ b/backend/src/config/environment.config.ts
@@ -43,16 +43,36 @@ class EnvironmentVariables {
   @IsString()
   DB_NAME: string;
 
+  @IsOptional()
+  @IsString()
+  JWT_SECRET?: string;
+
   @IsString()
   @ValidateIf((o) => o.NODE_ENV === 'production')
   @MinLength(32, {
     message:
-      'JWT_SECRET must be at least 32 characters long in production environment',
+      'JWT_ACCESS_SECRET must be at least 32 characters long in production environment',
   })
-  JWT_SECRET: string;
+  JWT_ACCESS_SECRET: string;
+
+  @IsString()
+  @ValidateIf((o) => o.NODE_ENV === 'production')
+  @MinLength(32, {
+    message:
+      'JWT_REFRESH_SECRET must be at least 32 characters long in production environment',
+  })
+  JWT_REFRESH_SECRET: string;
 
   @IsString()
   JWT_EXPIRES_IN: string;
+
+  @IsOptional()
+  @IsString()
+  JWT_ACCESS_EXPIRES_IN?: string;
+
+  @IsOptional()
+  @IsString()
+  JWT_REFRESH_EXPIRES_IN?: string;
 
   @IsString()
   STELLAR_NETWORK: string;
@@ -213,7 +233,11 @@ export function validateEnv(): EnvironmentVariables {
       DB_PASSWORD: process.env.DB_PASSWORD || 'password',
       DB_NAME: process.env.DB_NAME || 'stellarcert',
       JWT_SECRET: process.env.JWT_SECRET,
+      JWT_ACCESS_SECRET: process.env.JWT_ACCESS_SECRET || process.env.JWT_SECRET,
+      JWT_REFRESH_SECRET: process.env.JWT_REFRESH_SECRET || process.env.JWT_SECRET,
       JWT_EXPIRES_IN: process.env.JWT_EXPIRES_IN || '24h',
+      JWT_ACCESS_EXPIRES_IN: process.env.JWT_ACCESS_EXPIRES_IN || '15m',
+      JWT_REFRESH_EXPIRES_IN: process.env.JWT_REFRESH_EXPIRES_IN || '7d',
       STELLAR_NETWORK: process.env.STELLAR_NETWORK || 'testnet',
       STELLAR_HORIZON_URL:
         process.env.STELLAR_HORIZON_URL ||

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -24,12 +24,12 @@ import { AuthRateLimitMiddleware } from './middleware/auth-rate-limit.middleware
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        const secret = configService.get<string>('JWT_SECRET');
-        const expiresIn = (configService.get<string>('JWT_EXPIRES_IN') ||
-          '24h') as any;
+        const secret = configService.get<string>('JWT_ACCESS_SECRET');
+        const expiresIn = (configService.get<string>('JWT_ACCESS_EXPIRES_IN') ||
+          '15m') as any;
 
         if (!secret) {
-          throw new Error('JWT_SECRET must be configured');
+          throw new Error('JWT_ACCESS_SECRET must be configured');
         }
 
         return {

--- a/backend/src/modules/auth/services/jwt.service.ts
+++ b/backend/src/modules/auth/services/jwt.service.ts
@@ -26,7 +26,8 @@ export class JwtManagementService {
     const expiresIn = (this.configService.get<string>(
       'JWT_ACCESS_EXPIRES_IN',
     ) || '15m') as any;
-    return this.nestJwtService.signAsync(payload as any, { expiresIn });
+    const secret = this.configService.get<string>('JWT_ACCESS_SECRET');
+    return this.nestJwtService.signAsync(payload as any, { expiresIn, secret });
   }
 
   /**
@@ -36,7 +37,8 @@ export class JwtManagementService {
     const expiresIn = (this.configService.get<string>(
       'JWT_REFRESH_EXPIRES_IN',
     ) || '7d') as any;
-    return this.nestJwtService.signAsync(payload as any, { expiresIn });
+    const secret = this.configService.get<string>('JWT_REFRESH_SECRET');
+    return this.nestJwtService.signAsync(payload as any, { expiresIn, secret });
   }
 
   /**
@@ -51,7 +53,7 @@ export class JwtManagementService {
       }
 
       return await this.nestJwtService.verifyAsync(token, {
-        secret: this.configService.get<string>('JWT_SECRET'),
+        secret: this.configService.get<string>('JWT_ACCESS_SECRET'),
       });
     } catch (error) {
       throw new Error(`Invalid access token: ${error.message}`);
@@ -70,9 +72,7 @@ export class JwtManagementService {
       }
 
       return await this.nestJwtService.verifyAsync(token, {
-        secret:
-          this.configService.get<string>('JWT_REFRESH_SECRET') ||
-          this.configService.get<string>('JWT_SECRET'),
+        secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
       });
     } catch (error) {
       throw new Error(`Invalid refresh token: ${error.message}`);

--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -13,10 +13,10 @@ export interface JwtPayload {
 }
 
 function requireJwtSecret(configService: ConfigService): string {
-  const secret = configService.get<string>('JWT_SECRET');
+  const secret = configService.get<string>('JWT_ACCESS_SECRET');
 
   if (!secret) {
-    throw new Error('JWT_SECRET must be configured');
+    throw new Error('JWT_ACCESS_SECRET must be configured');
   }
 
   return secret;

--- a/backend/src/modules/notifications/notifications.controller.ts
+++ b/backend/src/modules/notifications/notifications.controller.ts
@@ -5,6 +5,7 @@ import {
   Body,
   Patch,
   Param,
+  Query,
   UseGuards,
   Request,
 } from '@nestjs/common';
@@ -20,9 +21,17 @@ export class NotificationsController {
   constructor(private readonly notificationsService: NotificationsService) {}
 
   @Get()
-  @ApiOperation({ summary: 'Get user recent notifications' })
-  getUserNotifications(@Request() req: any) {
-    return this.notificationsService.getUserNotifications(req.user.id);
+  @ApiOperation({ summary: 'Get user notifications (paginated)' })
+  getUserNotifications(
+    @Request() req: any,
+    @Query('page') page = 1,
+    @Query('limit') limit = 20,
+  ) {
+    return this.notificationsService.getUserNotifications(
+      req.user.id,
+      Number(page),
+      Number(limit),
+    );
   }
 
   @Patch('read-all')

--- a/backend/src/modules/notifications/notifications.module.ts
+++ b/backend/src/modules/notifications/notifications.module.ts
@@ -5,21 +5,12 @@ import { NotificationsController } from './notifications.controller';
 import { NotificationsGateway } from './notifications.gateway';
 import { Notification } from './entities/notification.entity';
 import { NotificationPreference } from './entities/notification-preference.entity';
-import { JwtModule } from '@nestjs/jwt';
-import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Notification, NotificationPreference]),
-    JwtModule.registerAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
-      useFactory: (configService: ConfigService) => ({
-        secret: configService.get<string>('JWT_SECRET'),
-      }),
-    }),
-    AuthModule, // Add this to import AuthModule
+    AuthModule,
   ],
   controllers: [NotificationsController],
   providers: [NotificationsService, NotificationsGateway],

--- a/backend/src/modules/notifications/notifications.service.ts
+++ b/backend/src/modules/notifications/notifications.service.ts
@@ -57,12 +57,18 @@ export class NotificationsService {
     return savedNotification;
   }
 
-  async getUserNotifications(userId: string): Promise<Notification[]> {
-    return this.notificationRepository.find({
+  async getUserNotifications(
+    userId: string,
+    page = 1,
+    limit = 20,
+  ): Promise<{ data: Notification[]; total: number; page: number; limit: number }> {
+    const [data, total] = await this.notificationRepository.findAndCount({
       where: { userId },
       order: { createdAt: 'DESC' },
-      take: 50,
+      skip: (page - 1) * limit,
+      take: limit,
     });
+    return { data, total, page, limit };
   }
 
   async markAsRead(

--- a/backend/src/modules/users/services/user-auth.service.ts
+++ b/backend/src/modules/users/services/user-auth.service.ts
@@ -179,7 +179,7 @@ export class UserAuthService {
     let payload: { sub: string } | null = null;
     try {
       const decoded = this.jwtService.verify(refreshToken, {
-        secret: this.configService.get<string>('JWT_SECRET'),
+        secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
       });
 
       if (!decoded || !decoded.sub || typeof decoded.sub !== 'string') {

--- a/frontend/src/context/NotificationContext.tsx
+++ b/frontend/src/context/NotificationContext.tsx
@@ -38,8 +38,8 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
         try {
             const token = tokenStorage.getAccessToken();
             if (!token) return;
-            const data = await apiClient<Notification[]>('/notifications');
-            setNotifications(data);
+            const response = await apiClient<{ data: Notification[]; total: number; page: number; limit: number }>('/notifications');
+            setNotifications(response.data);
         } catch (error) {
             console.error('Failed to fetch notifications:', error);
         }


### PR DESCRIPTION


- Use JWT_ACCESS_SECRET for signing/verifying access tokens and JWT_REFRESH_SECRET for refresh tokens instead of a shared JWT_SECRET. A compromised access token can no longer be used to forge refresh tokens.

- Added JWT_ACCESS_EXPIRES_IN (default 15m) and JWT_REFRESH_EXPIRES_IN (default 7d) env vars. JWT_SECRET is kept as an optional fallback so existing deployments migrate without immediate downtime.

- Updated auth.module.ts, common.module.ts, jwt-auth.guard.ts, jwt.strategy.ts, jwt.service.ts, and user-auth.service.ts to use the correct secret per token type.

- Removed the duplicate JwtModule.registerAsync (using stale JWT_SECRET) from NotificationsModule; the module now relies solely on the JwtModule exported by AuthModule.

- GET /notifications now accepts optional ?page and ?limit query params and returns { data, total, page, limit } instead of a bare array. Frontend NotificationContext updated to unwrap the paginated response.

Closes #477
Closes #478