### PR TITLE
fix(multisig): ensure approved certificate is actually issued after threshold is reached

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5434,9 +5434,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5454,9 +5451,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5474,9 +5468,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5494,9 +5485,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5514,9 +5502,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5534,9 +5519,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15089,9 +15071,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15113,9 +15092,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15137,9 +15113,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -15161,9 +15134,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/stellar-contracts/src/multisig.rs
+++ b/stellar-contracts/src/multisig.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, Address, Env, IntoVal, String, Symbol, Vec};
 
 use crate::{
     DataKey, MultisigConfig, OptionalRequestStatus, PaginatedResult, Pagination, PendingRequest,
@@ -324,13 +324,47 @@ impl MultisigCertificateContract {
             return false;
         }
 
-        // This would typically call the main certificate contract
-        // For now, we just update the status
+        request.issuer.require_auth();
+
+        let certificate_contract: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::CertificateContract)
+            .expect("Certificate contract not configured");
+
+        // Issue the actual certificate through the external CertificateContract
+        let _: () = env.invoke_contract(
+            &certificate_contract,
+            &Symbol::new(&env, "issue_certificate"),
+            soroban_sdk::vec![
+                &env,
+                request.id.clone().into_val(&env),
+                request.issuer.clone().into_val(&env),
+                request.recipient.clone().into_val(&env),
+                request.metadata.clone().into_val(&env),
+                Some(request.expires_at).into_val(&env),
+            ],
+        );
+
         request.status = RequestStatus::Issued;
         env.storage()
             .instance()
             .set(&DataKey::PendingRequest(request_id), &request);
         true
+    }
+
+    pub fn set_certificate_contract(env: Env, admin: Address, certificate_contract: Address) {
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::CertificateContract, &certificate_contract);
+    }
+
+    pub fn get_certificate_contract(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::CertificateContract)
+            .expect("Certificate contract not configured")
     }
 
     /// Get a pending request by ID

--- a/stellar-contracts/src/multisig_test.rs
+++ b/stellar-contracts/src/multisig_test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use super::multisig::*;
-use crate::{OptionalRequestStatus, Pagination, RequestStatus};
+use crate::{CertificateContract, CertificateContractClient, OptionalRequestStatus, Pagination, RequestStatus};
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
 
 #[test]
@@ -222,6 +222,14 @@ fn test_issue_approved_certificate() {
     client.approve_request(&request_id, &signer1);
     client.approve_request(&request_id, &signer2);
 
+    // Configure the external certificate contract and register the issuer
+    let certificate_contract_id = env.register_contract(None, CertificateContract);
+    let certificate_contract_address = Address::Contract(certificate_contract_id.clone());
+    let certificate_client = CertificateContractClient::new(&env, &certificate_contract_id);
+    certificate_client.initialize(&admin);
+    certificate_client.add_issuer(&issuer);
+    client.set_certificate_contract(&admin, &certificate_contract_address);
+
     // Issue the certificate
     let success = client.issue_approved_certificate(&request_id);
     assert!(success);
@@ -229,6 +237,9 @@ fn test_issue_approved_certificate() {
     // Check the request status
     let request = client.get_pending_request(&request_id);
     assert_eq!(request.status, RequestStatus::Issued);
+
+    // Verify the certificate was minted in CertificateContract
+    assert!(certificate_client.certificate_exists(&request_id));
 }
 
 #[test]

--- a/stellar-contracts/src/types.rs
+++ b/stellar-contracts/src/types.rs
@@ -47,6 +47,7 @@ pub enum DataKey {
     IssuerAdmin(Address),
     PendingRequest(String),
     IssuerRequestIds(Address),
+    CertificateContract,
     SignerRequestIds(Address),
     IssuerCertIds(Address),
     OwnerCertIds(Address),


### PR DESCRIPTION
## Summary

This fixes a critical bug in the multisig certificate flow where approvals were being recorded but no certificate was actually minted on-chain.

The issue was caused by `issue_approved_certificate()` updating the request status to `Issued` without calling `CertificateContract::issue_certificate()`.

---

## Changes

- Added missing cross-contract call to `CertificateContract::issue_certificate()`
- Ensured certificate is minted once multisig approval threshold is met
- Updated flow to only mark request as `Issued` after successful issuance

---

## Impact

- Fixes broken certificate issuance flow
- Ensures multisig approvals result in actual on-chain certificates
- Restores integrity of approval → issuance lifecycle

---

## Acceptance Criteria

- [x] Approved requests now trigger certificate minting
- [x] No state marked as `Issued` without actual certificate creation
- [x] Multisig flow completes end-to-end correctly

closes #514 